### PR TITLE
feat: sync docs and metadata with v3.5.7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-# 🚀 Pull Request Summary - v3.5.5
+# 🚀 Pull Request Summary - v3.5.7
 
 ## 📋 Description of Changes
-<!-- Briefly describe what this PR implements or fixes for v3.5.5 -->
+<!-- Briefly describe what this PR implements or fixes for v3.5.7 -->
 - [ ] Added new prompt kernel: `docs/prompt/prompt_kernel_v3.5.md`
 - [ ] Added evolution log: `docs/meta/prompt_evolution_log/v3.5.yaml`
 - [ ] Updated meta evaluation: `docs/meta/meta_evaluation.json`
@@ -9,7 +9,7 @@
 
 ---
 
-## 🗂 Affected Files (v3.5.5)
+## 🗂 Affected Files (v3.5.7)
 <!-- Check all that apply -->
 
 ### Core Files
@@ -38,7 +38,7 @@
 - [ ] Added test_memory_reflection.md to `/tests/golden_prompts/`
 - [ ] Added test_kpi_optimization.md to `/tests/golden_prompts/`
 - [ ] CI configured to detect and validate golden prompts
-- [ ] Golden prompts align with v3.5.5 kernel strategy
+- [ ] Golden prompts align with v3.5.7 kernel strategy
 
 ---
 
@@ -60,5 +60,5 @@ Ensure the following items are checked before requesting review:
 
 ### Golden Prompt Details
 - **Test Coverage**: Ensure all major prompt patterns are covered
-- **Version Compatibility**: All prompts are compatible with v3.5.5
+- **Version Compatibility**: All prompts are compatible with v3.5.7
 - **Validation**: CI pipeline includes golden prompt validation

--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -1,5 +1,5 @@
 ---
-name: CI Validate O3 Repo v3.5.5
+name: CI Validate O3 Repo v3.5.7
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented in this file.
 - Expanded configuration settings
 - Updated documentation and version metadata to 3.5.7
 - Added `world_agent_integration.md` integration guide
+- Added `executive_summary.md` with high-level overview
+- Indexed `72hr_campaign_sim.md` in `source_index.json`
 
 ## [v3.5.6] — 2025-05-31
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Key references:
 - docs/performance_marketing/*.md
 - docs/meta/prompt_genome.json  # Version and lineage tracking
 - docs/source_index.json
+- docs/executive_summary.md  # High-level system overview
+- docs/simulations/72hr_campaign_sim.md  # End-to-end lifecycle example
 
 Run the demo workflow:
 

--- a/docs/executive_summary.md
+++ b/docs/executive_summary.md
@@ -1,0 +1,16 @@
+# Executive Summary
+
+This document summarizes the ADK AI Marketing Operating System. It condenses the strategic context, agent architecture, prompt design, and deployment model described across the repository.
+
+## Key Highlights
+- **Multi-Agent Design** with specialized roles for research, content, campaign management, engagement, optimization, analytics, configuration, and governance.
+- **Advanced Prompt Engineering** patterns including few-shot examples, Chain-of-Thought reasoning, ReAct loops, and self-reflection prompts.
+- **Shared Memory** through semantic caching and persistent logs, enabling agents to collaborate and reuse knowledge.
+- **Self-Optimizing Feedback Loops** where agents adjust strategies based on performance metrics and ConfigAgent can roll back underperforming prompts.
+- **Cloud-Native Deployment** targeting Google Cloud services such as Cloud Run, Vertex AI, and Pub/Sub for scalable orchestration.
+- **72-Hour Campaign Simulation** demonstrates automated launch, optimization, and governance with fault recovery.
+
+## Related Documentation
+- [72-Hour PPC Campaign Simulation](simulations/72hr_campaign_sim.md)
+- [Agent System Overview](agent_system_overview.md)
+- [Prompt Kernel v3.5](prompt/prompt_kernel_v3.5.md)

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -7,8 +7,7 @@
         "name": "O3 Deep Research V3.5.7",
         "description": "Adds asynchronous event bus and logging utilities",
         "created_at": "2025-06-01",
-        "status": "superseded",
-        "superseded_by": "o3-deep-research-v3.5.7",
+        "status": "active",
         "components": [
           {"type": "role_definition", "version": "1.2"},
           {"type": "context_definition", "version": "1.4"},

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -649,7 +649,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "version": "v3.5.5",
+  "version": "v3.5.7",
   "prompt_layers": [
     {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
     {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
@@ -658,7 +658,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
     {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
   ],
   "last_update": "2025-05-23",
-  "registry_id": "O3_prompt_kernel_3.5.5"
+  "registry_id": "O3_prompt_kernel_3.5.7"
 }
 ```
 
@@ -666,7 +666,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "prompt_kernel_version": "v3.5.5",
+  "prompt_kernel_version": "v3.5.7",
   "coverage_score": 0.96,
   "coherence_rating": 0.93,
   "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -293,6 +293,27 @@
       "type": "documentation"
     },
     {
+      "name": "Executive Summary",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/executive_summary.md",
+      "tags": [
+        "overview",
+        "strategy",
+        "summary"
+      ],
+      "version": "3.5.7",
+      "type": "documentation"
+    },
+    {
+      "name": "72-Hour Campaign Simulation",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/simulations/72hr_campaign_sim.md",
+      "tags": [
+        "simulation",
+        "workflow"
+      ],
+      "version": "3.5.7",
+      "type": "documentation"
+    },
+    {
       "name": "A2A Protocol",
       "link": "https://github.com/AutogenStudio/autogen",
       "description": "The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.",

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -20,6 +20,7 @@ ADK/
     ├── integration_guide_o3.md
     ├── source_index.json
     ├── o3_deep_research_prompt.md
+    ├── executive_summary.md
     ├── meta/
     │   ├── version_diff_v3.5.6_to_v3.5.7.md
     │   └── ...
@@ -35,4 +36,6 @@ ADK/
         └── reforge_growth_loops.md
     ├── config_agent_overview.md
     ├── world_agent_integration.md
+    ├── simulations/
+    │   └── 72hr_campaign_sim.md
 ```

--- a/tests/golden_prompts/README.md
+++ b/tests/golden_prompts/README.md
@@ -1,4 +1,4 @@
-# Golden Prompts (v3.5.5)
+# Golden Prompts (v3.5.7)
 
 This directory contains reference prompts for validating the O3 Prompt Kernel architecture. These golden prompts serve as test cases to ensure the system behaves as expected across different scenarios.
 
@@ -39,7 +39,7 @@ bash scripts/validate_golden_prompts.sh
 
 ## Versioning
 
-- **Current Version**: 3.5.5
+- **Current Version**: 3.5.7
 - **Compatibility**: O3 Prompt Kernel v3.5.0+
 - **Last Updated**: 2025-05-30
 

--- a/tests/golden_prompts/test_config_adjustment.md
+++ b/tests/golden_prompts/test_config_adjustment.md
@@ -7,9 +7,9 @@ The ConfigAgent receives a routing weight update and must produce a diff summary
 ### EXPECTED
 - Shows YAML diff with before/after sections
 - Sends `config_push` notification to other agents
-- References version 3.5.5 in output
+- References version 3.5.7 in output
 
 ### NOTES
-Prompt Kernel: v3.5.5
+Prompt Kernel: v3.5.7
 
 **Tags:** config-agent, schema-diff

--- a/tests/golden_prompts/test_config_routing_diff.md
+++ b/tests/golden_prompts/test_config_routing_diff.md
@@ -6,9 +6,9 @@ ConfigAgent receives a new routing table with updated weights. Provide a summary
 
 ### EXPECTED
 - Outputs YAML diff highlighting weight changes
-- Sends `config_push` message noting version 3.5.5
+- Sends `config_push` message noting version 3.5.7
 - Mentions validation checklist
 
 ### NOTES
-Prompt Kernel: v3.5.5
+Prompt Kernel: v3.5.7
 **Tags:** config-agent, routing-diff

--- a/tests/golden_prompts/test_config_schema_diff.md
+++ b/tests/golden_prompts/test_config_schema_diff.md
@@ -7,9 +7,9 @@ The ConfigAgent receives a new schema with additional fields and modified defaul
 ### EXPECTED
 - Shows added and removed fields in diff format
 - Warns if any required fields are missing
-- Sends `config_push` notification referencing version 3.5.5
+- Sends `config_push` notification referencing version 3.5.7
 
 ### NOTES
-Prompt Kernel: v3.5.5
+Prompt Kernel: v3.5.7
 
 **Tags:** config-agent, schema-diff

--- a/tests/golden_prompts/test_config_schema_mutation.md
+++ b/tests/golden_prompts/test_config_schema_mutation.md
@@ -7,8 +7,8 @@ ConfigAgent receives a proposed schema change that alters field types. Summarize
 ### EXPECTED
 - Shows before/after schema block with highlights
 - Warns if new fields break backward compatibility
-- Mentions version 3.5.5 in the notification
+- Mentions version 3.5.7 in the notification
 
 ### NOTES
-Prompt Kernel: v3.5.5
+Prompt Kernel: v3.5.7
 **Tags:** config-agent, schema-mutation


### PR DESCRIPTION
## Summary
- add 72hr campaign simulation to source index
- update docs tree and README references
- bump version references to v3.5.7 across docs and workflows
- fix prompt genome metadata and prompt kernel registry
- update golden prompt tests for v3.5.7
- revert accidental npm lockfile changes

## Testing
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` *(warn-only)*
- `bash scripts/validate_golden_prompts.sh`
- *`markdownlint-cli2` failed: EHOSTUNREACH*

------
https://chatgpt.com/codex/tasks/task_b_683ba0930a4883338fd78efe017194b2