### PR TITLE
Implement heartbeat logic and doc updates

### DIFF
--- a/docs/agent_system_overview.md
+++ b/docs/agent_system_overview.md
@@ -84,3 +84,4 @@ await event_bus.publish("start_research", "email marketing trends")
 The 21 May prompt introduced a sequential flow diagram showing Research → Content → Campaign → Optimization → Analytics. See the [prompt kernel](prompt/prompt_kernel_v3.5.md#module-map) for visuals.
 
 For connection instructions refer to the [Integration Guide](integration_guide_o3.md).
+Additional design context can be found in the [21 May Improvement Notes](meta/improvement_notes_21May2025.md).

--- a/docs/config_agent_overview.md
+++ b/docs/config_agent_overview.md
@@ -20,3 +20,19 @@ after:
 ```
 
 This diff indicates a version bump and routing change which must pass `validate_golden_prompts.sh` before rollout.
+
+### Advanced Diff Example
+
+```yaml
+before:
+  prompt_version: 3.5.5
+  extra_filters:
+    - region: NA
+after:
+  prompt_version: 3.5.6
+  extra_filters:
+    - region: NA
+    - region: EU
+```
+
+Here the ConfigAgent introduces a new filter. The agent should generate a compatibility notice and increment the prompt version accordingly.

--- a/docs/external/analytics/amplitude_docs.md
+++ b/docs/external/analytics/amplitude_docs.md
@@ -20,5 +20,14 @@ Amplitude provides product analytics for measuring user engagement and conversio
 ## Example Code
 
 ```python
-# Example placeholder
+import requests
+
+# Send a basic test event
+payload = {
+    "api_key": "YOUR_API_KEY",
+    "events": [
+        {"event_type": "agent_heartbeat", "user_id": "demo"}
+    ]
+}
+requests.post("https://api2.amplitude.com/2/httpapi", json=payload)
 ```

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -173,7 +173,7 @@
   "versions": [
     {
       "tag": "v3.4",
-      "notes": "placeholder"
+      "notes": "First unified release with expanded source links; superseded by v3.5"
     },
     {
       "tag": "v3.5.6",

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -2,6 +2,8 @@
 
 ROLE: You are **O3 Deep Research** — an elite, autonomous research agent specialized in strategic, architectural, and prompt engineering intelligence. Your task is to produce a high-fidelity, deeply technical and strategic research report. This report will later serve as the foundation for a master LLM prompt that defines the development and deployment strategy for a multi-agent AI-powered marketing automation system.
 
+See the [21 May Improvement Notes](../meta/improvement_notes_21May2025.md) for additional design context.
+
 ---
 ## 📍 CONTEXT
 

--- a/docs/simulations/72hr_campaign_sim.md
+++ b/docs/simulations/72hr_campaign_sim.md
@@ -71,4 +71,5 @@ See [GovernanceAgent Overview](../governance_agent_overview.md) for escalation l
 2025-05-22T19:30Z GovernanceAgent missing heartbeat from OptimizationAgent; escalation issued
 2025-05-23T08:00Z CampaignAgent reduced bids by 15% after cost spike
 2025-05-23T16:45Z ConfigAgent restored prompt v3.5.3 and notified strategist
+2025-05-23T18:00Z GovernanceAgent heartbeat acknowledged for all agents
 ```

--- a/src/agents/governance_agent.py
+++ b/src/agents/governance_agent.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+import logging
+
 from core.base_agent import BaseAgent
 
 class GovernanceAgent(BaseAgent):
@@ -7,8 +10,17 @@ class GovernanceAgent(BaseAgent):
         super().__init__(name="GovernanceAgent")
 
     def run(self, status: str) -> str:
-        # Placeholder heartbeat check
-        return f"{self.name} reviewed status: {status}"
+        """Check heartbeat status and log the result."""
+        timestamp = datetime.utcnow().isoformat()
+
+        if status.lower() in {"ok", "alive", "ready"}:
+            message = f"{timestamp} {self.name} heartbeat acknowledged"
+            logging.info(message)
+        else:
+            message = f"{timestamp} {self.name} detected anomaly: {status}"
+            logging.warning(message)
+
+        return message
 
 if __name__ == "__main__":
     agent = GovernanceAgent()


### PR DESCRIPTION
## Summary
- replace placeholder entry for v3.4 in the prompt genome
- add example Amplitude API code snippet
- implement basic heartbeat check in `GovernanceAgent`
- expand config agent docs with advanced diff example
- link improvement notes from main docs and prompt kernel
- update simulation log

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `yamllint` *(fails: node_modules removed so using global)*
- `bash scripts/validate_golden_prompts.sh`


------
https://chatgpt.com/codex/tasks/task_b_683dc9e40f3c8333b0260ea61d81a5aa