### PR TITLE
Add link cache script and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project are documented in this file.
 - Updated documentation and version metadata to 3.5.7
 - Added `world_agent_integration.md` integration guide
 - Updated `source_index.json` with `72hr_campaign_sim.md` entry
+- Updated context test to version 3.5.7
+- Added unit tests for core utilities and agents
+- Added `refresh_link_cache.py` script for external link validation
+- Clarified prompt genome status and cleaned documentation
 
 ## [v3.5.6] — 2025-05-31
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [AGENTS Guide](AGENTS.md) - Short rules for using ChatGPT with this repo
 - [Agent System Overview](docs/agent_system_overview.md) - Module map and agent roles
 - [ConfigAgent Overview](docs/config_agent_overview.md) - Prompt configuration management
+- [Configuration Settings Reference](docs/config/settings_reference.md) - Details for `settings.yaml`
 - [GovernanceAgent Concept](docs/governance_agent_concept.md) - Proposed compliance layer
 - [World Agent Integration Blueprint](docs/world_agent_integration.md) - Connect external agents via the event bus
 - [Documentation Index](docs/tree.md) - Overview of all docs

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,6 +1,6 @@
 # Default configuration for ADK agents
-prompt_version: 3.5.7
-routing_weight: 1
-log_level: INFO
-event_bus: async
-max_queue_size: 100
+prompt_version: 3.5.7  # prompt kernel version
+routing_weight: 1      # weight for ConfigAgent routing
+log_level: INFO        # default logging level
+event_bus: async       # event bus type (async or sync)
+max_queue_size: 100    # max event queue length

--- a/docs/config/settings_reference.md
+++ b/docs/config/settings_reference.md
@@ -1,0 +1,11 @@
+# Configuration Settings Reference
+
+This document explains the keys defined in `config/settings.yaml`.
+
+| Key | Description |
+|-----|-------------|
+| `prompt_version` | Default prompt kernel version used by all agents |
+| `routing_weight` | Weighting factor applied by `ConfigAgent` when routing tasks |
+| `log_level` | Logging verbosity for the shared logger |
+| `event_bus` | Event bus implementation: `async` or `sync` |
+| `max_queue_size` | Maximum queue length for the async event bus |

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -7,8 +7,7 @@
         "name": "O3 Deep Research V3.5.7",
         "description": "Adds asynchronous event bus and logging utilities",
         "created_at": "2025-06-01",
-        "status": "superseded",
-        "superseded_by": "o3-deep-research-v3.5.7",
+        "status": "active",
         "components": [
           {"type": "role_definition", "version": "1.2"},
           {"type": "context_definition", "version": "1.4"},

--- a/examples/simple_workflow.py
+++ b/examples/simple_workflow.py
@@ -13,12 +13,20 @@ async def handle_research(msg: str) -> None:
     logger.info(server.route("research", msg))
     logger.info(server.route("content", msg))
 
+async def handle_optimize(msg: str) -> None:
+    logger.info(server.route("optimization", msg))
+    logger.info(server.route("analytics", msg))
+
 
 event_bus.subscribe("start_research", handle_research)
+event_bus.subscribe("start_optimize", handle_optimize)
 
 
 async def main() -> None:
-    await event_bus.publish("start_research", "email marketing trends")
+    await asyncio.gather(
+        event_bus.publish("start_research", "email marketing trends"),
+        event_bus.publish("start_optimize", "budget allocation"),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,3 +18,9 @@ Two helper scripts streamline validation and development:
   ```
 
 Both scripts exit non‑zero on failure so they can be used in automation.
+
+* `refresh_link_cache.py` – Checks external documentation links and updates `docs/link_cache.txt` with the latest HTTP status codes:
+
+  ```bash
+  python scripts/refresh_link_cache.py
+  ```

--- a/scripts/refresh_link_cache.py
+++ b/scripts/refresh_link_cache.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Refresh docs/link_cache.txt with current HTTP status codes."""
+import os
+import re
+import urllib.request
+import urllib.error
+
+CACHE_FILE = os.path.join('docs', 'link_cache.txt')
+ROOT = os.path.join('docs', 'external')
+
+def collect_links():
+    links = set()
+    for dirpath, _, filenames in os.walk(ROOT):
+        for name in filenames:
+            if not name.endswith('.md'):
+                continue
+            with open(os.path.join(dirpath, name), 'r', encoding='utf-8') as f:
+                for match in re.findall(r'https?://[^ )]+', f.read()):
+                    links.add(match)
+    return sorted(links)
+
+def check_link(url: str) -> int:
+    request = urllib.request.Request(url, method='HEAD')
+    try:
+        with urllib.request.urlopen(request, timeout=10) as resp:
+            return resp.getcode()
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return 0
+
+def main() -> None:
+    links = collect_links()
+    with open(CACHE_FILE, 'w', encoding='utf-8') as cache:
+        for url in links:
+            status = check_link(url)
+            cache.write(f"{url} {status}\n")
+    print(f"Updated {CACHE_FILE} with {len(links)} entries")
+
+if __name__ == '__main__':
+    main()

--- a/src/README.md
+++ b/src/README.md
@@ -22,6 +22,4 @@ src/
 └── mcp_server.py  # Minimal orchestrator
 ```
 
-These stubs illustrate the basic interfaces used by more advanced agents.
-
 These stubs illustrate the basic structure of an agent so new contributors can build their own.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
-from .base_agent import BaseAgent
-from .sample_agent import EchoAgent
-from .research_agent import ResearchAgent
+from .core.base_agent import BaseAgent
+from .agents.sample_agent import EchoAgent
+from .agents.research_agent import ResearchAgent
 
 __all__ = ["BaseAgent", "EchoAgent", "ResearchAgent"]

--- a/src/agents/analytics_agent.py
+++ b/src/agents/analytics_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class AnalyticsAgent(BaseAgent):

--- a/src/agents/campaign_agent.py
+++ b/src/agents/campaign_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class CampaignAgent(BaseAgent):

--- a/src/agents/config_agent.py
+++ b/src/agents/config_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 from pathlib import Path
 import yaml
 

--- a/src/agents/content_agent.py
+++ b/src/agents/content_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class ContentAgent(BaseAgent):

--- a/src/agents/engagement_agent.py
+++ b/src/agents/engagement_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class EngagementAgent(BaseAgent):

--- a/src/agents/governance_agent.py
+++ b/src/agents/governance_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 class GovernanceAgent(BaseAgent):
     """Prototype agent to monitor other agents and handle escalation."""

--- a/src/agents/optimization_agent.py
+++ b/src/agents/optimization_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class OptimizationAgent(BaseAgent):

--- a/src/agents/research_agent.py
+++ b/src/agents/research_agent.py
@@ -1,4 +1,4 @@
-from core.base_agent import BaseAgent
+from ..core.base_agent import BaseAgent
 
 
 class ResearchAgent(BaseAgent):

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from .logger import get_logger
 
 
@@ -5,10 +7,10 @@ class EventBus:
     """Very small publish/subscribe bus with basic logging."""
 
     def __init__(self) -> None:
-        self.subscribers: dict[str, list[callable]] = {}
+        self.subscribers: dict[str, list[Callable[[str], None]]] = {}
         self.logger = get_logger(self.__class__.__name__)
 
-    def subscribe(self, topic: str, callback: callable) -> None:
+    def subscribe(self, topic: str, callback: Callable[[str], None]) -> None:
         self.logger.debug("Subscriber added to %s", topic)
         self.subscribers.setdefault(topic, []).append(callback)
 

--- a/tests/context/test_o3_context.json
+++ b/tests/context/test_o3_context.json
@@ -8,7 +8,7 @@
     "docs/kaggle_prompt_engineering_summary.md"
   ],
   "external_sources_minimum": 10,
-  "prompt_version": "v3.0.0",
+  "prompt_version": "v3.5.7",
   "metadata_check": {
     "semantic_tags_present": true,
     "version_tracking_enabled": true,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,25 @@
+import unittest
+from src.agents.research_agent import ResearchAgent
+try:
+    from src.agents.config_agent import ConfigAgent  # type: ignore
+    YAML_AVAILABLE = True
+except Exception:
+    YAML_AVAILABLE = False
+
+class TestAgents(unittest.TestCase):
+    def test_research_agent(self):
+        agent = ResearchAgent()
+        result = agent.run('ai marketing')
+        self.assertIn('researched', result)
+
+    def test_config_agent_load(self):
+        if not YAML_AVAILABLE:
+            self.skipTest('yaml library not available')
+        agent = ConfigAgent()
+        settings = agent.load_settings()
+        self.assertIsInstance(settings, dict)
+        result = agent.run('')
+        self.assertTrue(result.startswith('ConfigAgent loaded'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,24 @@
+import unittest
+from src.core.event_bus import EventBus
+from src.core.async_event_bus import AsyncEventBus
+import asyncio
+
+class TestEventBus(unittest.TestCase):
+    def test_publish_subscribe(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe('topic', lambda m: received.append(m))
+        bus.publish('topic', 'hello')
+        self.assertEqual(received, ['hello'])
+
+    def test_async_publish_subscribe(self):
+        bus = AsyncEventBus()
+        received = []
+        async def handler(msg: str) -> None:
+            received.append(msg)
+        bus.subscribe('topic', handler)
+        asyncio.run(bus.publish('topic', 'async'))
+        self.assertEqual(received, ['async'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 📋 Description of Changes
- improve documentation consistency and add config settings reference
- clarify prompt genome status and update context version
- extend async workflow example and add link cache refresh script
- add unit tests for core event bus and agents
- clean up agent imports and event bus type hints

## 🗂 Affected Files (v3.5.5)
- [x] `docs/config/settings_reference.md`
- [x] `CHANGELOG.md`
- [x] `README.md`
- [x] `docs/meta/prompt_genome.json`
- [x] `config/settings.yaml`
- [x] `examples/simple_workflow.py`
- [x] `scripts/refresh_link_cache.py`
- [x] `scripts/README.md`
- [x] `src/**`
- [x] `tests/**`

## 🧪 Golden Prompt Integration
- [x] CI validates existing golden prompts

------
https://chatgpt.com/codex/tasks/task_b_683dcf2b0e288333a491e035c97bb77d