### PR TITLE
Add callback types module

### DIFF
--- a/src/core/async_event_bus.py
+++ b/src/core/async_event_bus.py
@@ -1,19 +1,14 @@
 import asyncio
 from collections import defaultdict
-from typing import Awaitable, Callable, TypeAlias
-
-AsyncSubscriber: TypeAlias = Callable[[str], Awaitable[None]]
-
-# Callback type alias for async subscribers
-AsyncSubscriber = Callable[[str], Awaitable[None]]
+from .types import AsyncCallback
 
 class AsyncEventBus:
     """Simple asyncio-based publish/subscribe bus."""
 
     def __init__(self) -> None:
-        self.subscribers: dict[str, list[AsyncSubscriber]] = defaultdict(list)
+        self.subscribers: dict[str, list[AsyncCallback]] = defaultdict(list)
 
-    def subscribe(self, topic: str, callback: AsyncSubscriber) -> None:
+    def subscribe(self, topic: str, callback: AsyncCallback) -> None:
         self.subscribers[topic].append(callback)
 
     async def publish(self, topic: str, message: str) -> None:

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -1,16 +1,15 @@
-from typing import Callable
-
 from .logger import get_logger
+from .types import Callback
 
 
 class EventBus:
     """Very small publish/subscribe bus with basic logging."""
 
     def __init__(self) -> None:
-        self.subscribers: dict[str, list[Callable[[str], None]]] = {}
+        self.subscribers: dict[str, list[Callback]] = {}
         self.logger = get_logger(self.__class__.__name__)
 
-    def subscribe(self, topic: str, callback: Callable[[str], None]) -> None:
+    def subscribe(self, topic: str, callback: Callback) -> None:
         self.logger.debug("Subscriber added to %s", topic)
         self.subscribers.setdefault(topic, []).append(callback)
 

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -1,0 +1,4 @@
+from typing import Callable, Awaitable
+
+Callback = Callable[[str], None]
+AsyncCallback = Callable[[str], Awaitable[None]]


### PR DESCRIPTION
## Summary
- add common Callback and AsyncCallback aliases
- refactor event bus modules to use new aliases

## Testing
- `python -m unittest discover tests`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `python scripts/refresh_link_cache.py` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_b_683dee5d6ca083339ccfaf71f6478d97