### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,17 @@ repos:
         name: markdownlint
         entry: markdownlint-cli2
         language: node
-        pass_filenames: false
-        args: ['docs/**/*.md', '!docs/legacy/**']
+        types: [markdown]
   - repo: local
     hooks:
       - id: yamllint
         name: yamllint
-        entry: bash -c 'yamllint config/settings.yaml $(find docs -name "*.yaml")'
+        entry: yamllint
+        language: system
+        types: [yaml]
+      - id: validate-golden-prompts
+        name: validate-golden-prompts
+        entry: bash scripts/validate_golden_prompts.sh
         language: system
         pass_filenames: false
       - id: unit-tests

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ Note: The `node_modules/` directory is excluded via `.gitignore` to avoid large 
 3. The current release version is stored in the `VERSION` file and exposed as
    `src.__version__` for programmatic access.
 
+### Pre-commit
+Install the pre-commit framework and set up the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit` will execute markdownlint, yamllint, golden prompt validation, and unit tests.
+
 ## 📚 Core References
 
 - [Google ADK Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-development-kit/quickstart)


### PR DESCRIPTION
## Summary
- manage linting & testing with pre-commit
- document how to install hooks

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `bash scripts/validate_golden_prompts.sh`
- `python -m unittest discover tests`

`markdownlint-cli2` was not available in the container.

------
https://chatgpt.com/codex/tasks/task_b_683dfb9c11708333a8f13ed6113f8690