### PR TITLE
fix: update legacy prompt path in CI

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -144,7 +144,7 @@ jobs:
               fi
             done
           test -f docs/performance_marketing/reforge_growth_loops.md
-          test -f docs/prompt/prompt_kernel_v3.4.md
+          test -f docs/legacy/prompt/prompt_kernel_v3.4.md
           test -f docs/meta/prompt_genome.json
 
       - name: Refresh Link Cache


### PR DESCRIPTION
## Summary
- correct path for v3.4 prompt kernel in workflow

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .github/workflows/validate_repo.yml`
- `grep -RniE 'TODO:|Coming soon' docs/ --include='*.md' --include='*.yaml' --include='*.yml' --exclude-dir=legacy`
- `test -f docs/prompt/prompt_kernel_v3.5.md`
- `test -f docs/meta/prompt_evolution_log/v3.5.yaml`
- `test -f docs/meta/meta_evaluation.json`
- `test -f docs/meta/prompt_genome.json`
- `test -f docs/source_index.json`
- `test -f README.md`
- `test -f CHANGELOG.md`
- `test -f tests/golden_prompts/test_prompt_coordinator.md`
- `test -f tests/golden_prompts/test_memory_reflection.md`
- `test -f tests/golden_prompts/test_kpi_optimization.md`
- `for file in tests/golden_prompts/*.md; do if [[ $(basename "$file") == "README.md" ]]; then continue; fi; for section in "INPUT" "EXPECTED" "NOTES"; do grep -q "^### $section" "$file"; done; grep -q '^**Tags:**' "$file"; grep -q 'v3\.5' "$file"; done`
- `version=$(jq -r '.versions[] | select(.tag=="v3.4")' docs/meta/prompt_genome.json); if [ -z "$version" ]; then echo missing; else echo found; fi`
- `curl -s --head --location --max-time 10 --fail https://cloud.google.com/ai >/dev/null && echo OK || echo FAIL` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_b_683e0ad5f97483339112c80cb6f5eb51