### PR TITLE
Update docs for v3.5.8

### DIFF
--- a/docs/o3_deep_research_prompt.md
+++ b/docs/o3_deep_research_prompt.md
@@ -115,5 +115,5 @@ BEGIN_COT
 ---
 
 Created by: `PromptForge`
-Prompt version: `v3.5.7`
+Prompt version: `v3.5.8`
 Last updated: `2025-06-01`

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -649,7 +649,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "version": "v3.5.7",
+  "version": "v3.5.8",
   "prompt_layers": [
     {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
     {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
@@ -658,7 +658,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
     {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
   ],
   "last_update": "2025-05-23",
-  "registry_id": "O3_prompt_kernel_3.5.7"
+  "registry_id": "O3_prompt_kernel_3.5.8"
 }
 ```
 
@@ -666,7 +666,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "prompt_kernel_version": "v3.5.7",
+  "prompt_kernel_version": "v3.5.8",
   "coverage_score": 0.96,
   "coherence_rating": 0.93,
   "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
@@ -681,7 +681,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
 
 ```yaml
-version: 3.5.7
+version: 3.5.8
 reviewed_on: 2025-05-23
 kernel_strengths:
   - Modular role-per-agent mapping


### PR DESCRIPTION
## Summary
- bump prompt version references to v3.5.8
- update kernel registry id and metadata

## Testing
- `markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'` *(fails: command not found)*
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- manual checks for required files
- version consistency check
- golden prompt validation
- `python scripts/refresh_link_cache.py` *(fails: network issue)*
- basic link check with curl *(fails: network issue)*


------
https://chatgpt.com/codex/tasks/task_b_683e297133d483339caeadb9a9fb77f4