### PR TITLE
feat: add KPI calculations to MetricsCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Added unit tests for core utilities and agents
 - Added `refresh_link_cache.py` script for external link validation
 - Clarified prompt genome status and cleaned documentation
+- Added `MetricsCollector` with KPI calculations and docs
 
 ## [v3.5.6] — 2025-05-31
 

--- a/docs/analytics/metrics_pipeline.md
+++ b/docs/analytics/metrics_pipeline.md
@@ -1,0 +1,18 @@
+# Metrics Pipeline
+
+This page outlines how raw campaign metrics are turned into KPIs.
+
+## Raw Metrics
+- **Impressions**
+- **Clicks**
+- **Cost**
+- **Conversions**
+- **Revenue**
+
+## KPI Calculations
+- **CTR (Click-Through Rate)** = Clicks / Impressions
+- **CPC (Cost Per Click)** = Cost / Clicks
+- **Conversion Rate** = Conversions / Clicks
+- **ROAS (Return on Ad Spend)** = Revenue / Cost
+
+The `MetricsCollector.collect()` method aggregates raw values and computes these KPIs for use by analytics agents.

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -690,6 +690,17 @@
       ],
       "version": "3.5.7",
       "type": "documentation"
+    },
+    {
+      "name": "Metrics Pipeline",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/analytics/metrics_pipeline.md",
+      "tags": [
+        "analytics",
+        "kpi",
+        "v3.5.7"
+      ],
+      "version": "3.5.7",
+      "type": "documentation"
     }
   ],
   "metadata": {

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -1,0 +1,40 @@
+class MetricsCollector:
+    """Simple metrics collector that aggregates raw counts and computes KPIs."""
+
+    def __init__(self) -> None:
+        self.records = []
+
+    def add(self, impressions: int, clicks: int, cost: float, conversions: int, revenue: float) -> None:
+        """Add a new set of raw metrics."""
+        self.records.append({
+            "impressions": impressions,
+            "clicks": clicks,
+            "cost": cost,
+            "conversions": conversions,
+            "revenue": revenue,
+        })
+
+    def collect(self) -> dict:
+        """Return aggregated metrics along with computed KPIs."""
+        total_impressions = sum(r["impressions"] for r in self.records)
+        total_clicks = sum(r["clicks"] for r in self.records)
+        total_cost = sum(r["cost"] for r in self.records)
+        total_conversions = sum(r["conversions"] for r in self.records)
+        total_revenue = sum(r["revenue"] for r in self.records)
+
+        ctr = (total_clicks / total_impressions) if total_impressions else 0.0
+        cpc = (total_cost / total_clicks) if total_clicks else 0.0
+        conversion_rate = (total_conversions / total_clicks) if total_clicks else 0.0
+        roas = (total_revenue / total_cost) if total_cost else 0.0
+
+        return {
+            "impressions": total_impressions,
+            "clicks": total_clicks,
+            "cost": total_cost,
+            "conversions": total_conversions,
+            "revenue": total_revenue,
+            "CTR": ctr,
+            "CPC": cpc,
+            "ConversionRate": conversion_rate,
+            "ROAS": roas,
+        }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import unittest
 from src.core.event_bus import EventBus
 from src.core.async_event_bus import AsyncEventBus
+from src.core.metrics import MetricsCollector
 import asyncio
 
 class TestEventBus(unittest.TestCase):
@@ -19,6 +20,28 @@ class TestEventBus(unittest.TestCase):
         bus.subscribe('topic', handler)
         asyncio.run(bus.publish('topic', 'async'))
         self.assertEqual(received, ['async'])
+
+
+class TestMetricsCollector(unittest.TestCase):
+    def test_collect_kpis(self):
+        mc = MetricsCollector()
+        mc.add(impressions=1000, clicks=100, cost=50.0, conversions=10, revenue=200.0)
+        result = mc.collect()
+        self.assertEqual(result['impressions'], 1000)
+        self.assertEqual(result['clicks'], 100)
+        self.assertAlmostEqual(result['CTR'], 0.1)
+        self.assertAlmostEqual(result['CPC'], 0.5)
+        self.assertAlmostEqual(result['ConversionRate'], 0.1)
+        self.assertAlmostEqual(result['ROAS'], 4.0)
+
+    def test_zero_division(self):
+        mc = MetricsCollector()
+        mc.add(impressions=0, clicks=0, cost=0.0, conversions=0, revenue=0.0)
+        result = mc.collect()
+        self.assertEqual(result['CTR'], 0.0)
+        self.assertEqual(result['CPC'], 0.0)
+        self.assertEqual(result['ConversionRate'], 0.0)
+        self.assertEqual(result['ROAS'], 0.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 📋 Description of Changes
- implemented `MetricsCollector` with CTR, CPC, Conversion Rate and ROAS computation
- documented KPI formulas in `docs/analytics/metrics_pipeline.md`
- updated `source_index.json` with new documentation entry
- added unit tests for metrics collector
- updated changelog for v3.5.7

## 🗂 Affected Files (v3.5.7)
- `CHANGELOG.md`
- `docs/analytics/metrics_pipeline.md`
- `docs/source_index.json`
- `src/core/metrics.py`
- `tests/test_core.py`

## ✅ Validation Checklist
- [x] `markdownlint-cli2` passed
- [x] `yamllint` passed
- [x] `jq` JSON validation passed
- [x] required files present
- [x] version consistency check
- [x] golden prompt validation passed
- [x] `pytest` passed

------
https://chatgpt.com/codex/tasks/task_b_683e34e493508333a95b171c44e11691