### PR TITLE
feat: support CSV export in ReportGenerator

### DIFF
--- a/docs/reporting_dashboard.md
+++ b/docs/reporting_dashboard.md
@@ -1,0 +1,9 @@
+# Reporting Dashboard
+
+The reporting dashboard centralizes campaign metrics for quick review.
+
+## Features
+- View aggregated metrics in real time
+- Generate shareable reports for stakeholders
+- Export metrics to JSON
+- Export metrics to CSV for deeper analysis

--- a/examples/ads_integration_workflow.py
+++ b/examples/ads_integration_workflow.py
@@ -1,0 +1,17 @@
+"""Example workflow integrating MetricsCollector and ReportGenerator."""
+from src.core.metrics import MetricsCollector
+from src.core.reporting import ReportGenerator
+
+
+def main() -> None:
+    collector = MetricsCollector()
+    collector.add(impressions=1200, clicks=160, cost=80.0, conversions=20, revenue=320.0)
+    metrics = collector.collect()
+
+    reporter = ReportGenerator()
+    reporter.export_csv(metrics, "ads_metrics.csv")
+    print("Metrics exported to ads_metrics.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,3 +1,4 @@
 from .event_bus import EventBus
 from .async_event_bus import AsyncEventBus
 from .logger import get_logger
+from .reporting import ReportGenerator

--- a/src/core/reporting.py
+++ b/src/core/reporting.py
@@ -1,0 +1,32 @@
+import csv
+from collections.abc import Iterable, Mapping
+
+
+class ReportGenerator:
+    """Generate reports from metrics and export them."""
+
+    def to_markdown(self, metrics: Mapping[str, float]) -> str:
+        """Return metrics formatted as a Markdown table."""
+        header = "| Metric | Value |"
+        separator = "| --- | --- |"
+        lines = [header, separator]
+        for key, value in metrics.items():
+            lines.append(f"| {key} | {value} |")
+        return "\n".join(lines)
+
+    def export_csv(
+        self, metrics: Mapping[str, float] | Iterable[Mapping[str, float]], path: str
+    ) -> None:
+        """Write metrics to a CSV file."""
+        if isinstance(metrics, Mapping):
+            rows = [metrics]
+        else:
+            rows = list(metrics)
+            if not rows:
+                raise ValueError("No metrics to export")
+
+        fieldnames = list(rows[0].keys())
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)


### PR DESCRIPTION
## Summary
- add `ReportGenerator` to export metrics to CSV
- document CSV export in `reporting_dashboard.md`
- show basic usage in `ads_integration_workflow.py`

## Testing
- `yamllint` *(with warnings)*
- `jq` on JSON files
- `PYTHONPATH=. pytest -q`
- `scripts/refresh_link_cache.py` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_b_683e3b8d996c8333a00c940be36648ca