### PR TITLE
chore: expand 72hr simulation example

### DIFF
--- a/docs/simulations/72hr_campaign_sim.md
+++ b/docs/simulations/72hr_campaign_sim.md
@@ -72,3 +72,32 @@ See [GovernanceAgent Overview](../governance_agent_overview.md) for escalation l
 2025-05-23T08:00Z CampaignAgent reduced bids by 15% after cost spike
 2025-05-23T16:45Z ConfigAgent restored prompt v3.5.3 and notified strategist
 ```
+
+## API Integration Examples
+
+These snippets show how agents call the ad platform APIs. Results flow into the
+[metrics pipeline](../analytics/metrics_pipeline.md) and feed the
+[A/B testing framework](../ab_testing_framework.md).
+
+```python
+# Google Ads API sample
+google_client = GoogleAdsClient(config="google-ads.yaml")
+try:
+    report = google_client.fetch_report(customer_id="123-456-7890")
+except Exception as err:  # GoogleAdsException in production
+    logger.error("Google Ads request failed: %s", err)
+    # Continue with cached metrics
+```
+
+```python
+# Meta Ads API sample
+meta_client = MetaAdsClient(access_token="TOKEN")
+try:
+    insights = meta_client.get_insights(account_id="act_987654321")
+except Exception as err:  # MetaAdsError in production
+    logger.warning("Meta Ads request failed: %s", err)
+    # Skip this update but continue optimization loop
+```
+
+**Note:** Handle API errors gracefully so the simulation continues even when a
+request fails.


### PR DESCRIPTION
## Summary
- expand the 72hr campaign simulation docs with API snippets

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .`
- `bash scripts/validate_golden_prompts.sh`
- `python scripts/refresh_link_cache.py`
- `python -m unittest discover tests`
- `grep -rEo 'https?://[^"\) >]+' docs/ README.md | grep -v 'localhost\|example\.com' | sort -u | while read -r url; do curl -s --head --location --max-time 10 --fail "$url" >/dev/null && echo OK $url || echo Broken $url; done`

------
https://chatgpt.com/codex/tasks/task_b_683e3ed183548333be50ea7d2d06f576