### PR TITLE
feat: expand reforge growth loops

### DIFF
--- a/docs/performance_marketing/reforge_growth_loops.md
+++ b/docs/performance_marketing/reforge_growth_loops.md
@@ -35,20 +35,34 @@ Agents shouldn't act in isolation — design prompt interfaces that reinforce sy
 ## Growth Loop Types
 
 ### Acquisition Loops
-- **Metrics:** Activation rate, cost per acquisition, first purchase rate
-- **CampaignAgent Example:** publishes `campaign.launch` events and adjusts targeting when `campaign.metrics` are received via the AsyncEventBus
+- **Metrics:**
+  - **Activation rate:** percent of new users who complete the first key action
+  - **Cost per acquisition:** ad spend divided by number of new users
+  - **First purchase rate:** share of users who make an initial transaction
+- **CampaignAgent Example:** publishes `campaign.launch` events and adapts targeting whenever `campaign.metrics` arrive on the AsyncEventBus
 
 ### Engagement Loops
-- **Metrics:** Session frequency, retention rate, reactivation rate
+- **Metrics:**
+  - **Session frequency:** how often active users return per week
+  - **Retention rate:** percent of users retained after a given period
+  - **Reactivation rate:** number of dormant users re-engaged
 - **EngagementAgent Example:** listens for `user.engaged` events and triggers follow-up sequences over the AsyncEventBus
 
 ### Referral Loops
-- **Metrics:** Viral coefficient, invitation conversion rate, share rate
+- **Metrics:**
+  - **Viral coefficient:** average number of new users generated per existing user
+  - **Invitation conversion rate:** signups divided by invitations sent
+  - **Share rate:** percentage of users actively sharing content
 - **CampaignAgent Example:** distributes referral codes and tracks signups through UTM events on the AsyncEventBus
 
 ### AsyncEventBus Example
 ```python
+from event_bus import AsyncEventBus
+
+event_bus = AsyncEventBus()
 event_bus.subscribe("campaign.launch", CampaignAgent.handle_launch)
 event_bus.subscribe("user.engage", EngagementAgent.handle_engagement)
+
+# Kick off a campaign and notify engagement handlers when users respond
 await event_bus.publish("campaign.launch", "spring_promo")
 ```

--- a/docs/performance_marketing/reforge_growth_loops.md
+++ b/docs/performance_marketing/reforge_growth_loops.md
@@ -31,3 +31,24 @@ Agents shouldn't act in isolation — design prompt interfaces that reinforce sy
 | CampaignAgent | UTM loop-based campaign learning     | "Label campaigns for loop learnback"      |
 | ContentAgent  | Retention-primed sequences           | "Generate follow-up anchored to last open"|
 | ResearchAgent | Experiment roadmap generation        | "List 3 high-impact tests with feedback"  |
+
+## Growth Loop Types
+
+### Acquisition Loops
+- **Metrics:** Activation rate, cost per acquisition, first purchase rate
+- **CampaignAgent Example:** publishes `campaign.launch` events and adjusts targeting when `campaign.metrics` are received via the AsyncEventBus
+
+### Engagement Loops
+- **Metrics:** Session frequency, retention rate, reactivation rate
+- **EngagementAgent Example:** listens for `user.engaged` events and triggers follow-up sequences over the AsyncEventBus
+
+### Referral Loops
+- **Metrics:** Viral coefficient, invitation conversion rate, share rate
+- **CampaignAgent Example:** distributes referral codes and tracks signups through UTM events on the AsyncEventBus
+
+### AsyncEventBus Example
+```python
+event_bus.subscribe("campaign.launch", CampaignAgent.handle_launch)
+event_bus.subscribe("user.engage", EngagementAgent.handle_engagement)
+await event_bus.publish("campaign.launch", "spring_promo")
+```


### PR DESCRIPTION
## 📋 Description of Changes
- expanded growth loop documentation with acquisition, engagement and referral sections
- included AsyncEventBus examples for CampaignAgent and EngagementAgent

## 🗂 Affected Files (v3.5.7)
- [x] `docs/performance_marketing/reforge_growth_loops.md`

## ✅ Validation Checklist
- [x] No `TODO:` or `Coming soon` remaining
- [ ] Links (internal/external) validated
- [ ] `source_index.json` updated if new `.md` was added
- [ ] `CHANGELOG.md` updated with version bump
- [x] PR title follows format: `feat:` `fix:` `chore:` etc.
- [x] Golden prompts pass validation checks
- [ ] All tests are passing

## 🧠 Notes & Context
N/A

------
https://chatgpt.com/codex/tasks/task_b_683e55d701d88333b4ed67967a80ca05