### PR TITLE
fix: remove duplicate link cache refresh

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -144,8 +144,6 @@ jobs:
             echo "✅ $file is valid"
           done
 
-      - name: Refresh Link Cache
-        run: python scripts/refresh_link_cache.py
 
       - name: Broken Link Check (Basic)
         if: github.event_name == 'push'  # Only run on push to reduce API calls


### PR DESCRIPTION
## Summary
- remove the duplicate `Refresh Link Cache` step
- ensure cache refresh uses `python3`

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .github/workflows/validate_repo.yml`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`

------
https://chatgpt.com/codex/tasks/task_b_683e69d3718483338ff77d57821e7f6e