### PR TITLE
Fix version inconsistencies

### DIFF
--- a/docs/meta/meta_evaluation.json
+++ b/docs/meta/meta_evaluation.json
@@ -3,7 +3,7 @@
   "evaluation_date": "2025-06-01",
   "evaluation_framework": {
     "name": "O3 Deep Research Evaluation Framework",
-    "version": "3.5.8"
+    "version": "3.5.7"
   },
   "evaluation_metrics": [
     {
@@ -113,7 +113,7 @@
       "version": "1.0.1",
       "date": "2025-06-01",
       "changes": [
-        "Updated evaluation framework to version 3.5.8"
+        "Updated evaluation framework to version 3.5.7"
       ]
     }
   ]

--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -183,7 +183,7 @@
       "notes": "async event bus, logging and example workflow"
     },
     {
-      "tag": "v3.5.8",
+      "tag": "v3.5.7",
       "notes": "marketing platform integrations and metrics pipeline"
     }
   ]

--- a/docs/o3_deep_research_prompt.md
+++ b/docs/o3_deep_research_prompt.md
@@ -115,5 +115,5 @@ BEGIN_COT
 ---
 
 Created by: `PromptForge`
-Prompt version: `v3.5.8`
+Prompt version: `v3.5.7`
 Last updated: `2025-06-01`

--- a/docs/prompt/prompt_kernel_v3.5.md
+++ b/docs/prompt/prompt_kernel_v3.5.md
@@ -649,7 +649,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "version": "v3.5.8",
+  "version": "v3.5.7",
   "prompt_layers": [
     {"id": "core-cof-ppc-001", "agent": "ResearchAgent", "pattern": "chain-of-thought"},
     {"id": "creative-tone-v2", "agent": "ContentAgent", "pattern": "few-shot"},
@@ -658,7 +658,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
     {"id": "optimization-tuner-auto", "agent": "OptimizationAgent", "pattern": "self-calibrating"}
   ],
   "last_update": "2025-05-23",
-  "registry_id": "O3_prompt_kernel_3.5.8"
+  "registry_id": "O3_prompt_kernel_3.5.7"
 }
 ```
 
@@ -666,7 +666,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 
 ```json
 {
-  "prompt_kernel_version": "v3.5.8",
+  "prompt_kernel_version": "v3.5.7",
   "coverage_score": 0.96,
   "coherence_rating": 0.93,
   "prompt_patterns_utilized": ["few-shot", "chain-of-thought", "semantic caching", "ReAct", "self-reflection"],
@@ -681,7 +681,7 @@ All actions are logged in `logs/agents/{agent}.json` for traceability.
 Store evolution notes in `/meta/prompt_evolution_log/v3.5.yaml` using the format:
 
 ```yaml
-version: 3.5.8
+version: 3.5.7
 reviewed_on: 2025-05-23
 kernel_strengths:
   - Modular role-per-agent mapping


### PR DESCRIPTION
## Summary
- keep repository at version 3.5.7
- update prompt docs, meta evaluation and prompt genome to use v3.5.7 consistently

## Testing
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `for file in tests/golden_prompts/*.md; do ...; done`
- `python3 scripts/refresh_link_cache.py`

------
https://chatgpt.com/codex/tasks/task_b_683e8c3f50e88333872beb972eb64438