### PR TITLE
feat: index performance marketing docs

### DIFF
--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -190,7 +190,7 @@
       ]
     },
     {
-      "name": "IBM Developer – AI Technology",
+      "name": "IBM Developer \u2013 AI Technology",
       "link": "https://developer.ibm.com/technologies/artificial-intelligence/",
       "tags": [
         "ibm",
@@ -261,6 +261,94 @@
       ]
     },
     {
+      "name": "Google Performance Marketing Insights",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/google_insights_summary.md",
+      "tags": [
+        "google",
+        "automation",
+        "marketing",
+        "optimization"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "HubSpot AI Automation Framework",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/hubspot_ai_automation.md",
+      "tags": [
+        "hubspot",
+        "automation",
+        "lead-scoring",
+        "personalization"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "McKinsey AI in Marketing Strategy",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/mckinsey_ai_marketing.md",
+      "tags": [
+        "mckinsey",
+        "ai-strategy",
+        "enterprise",
+        "analytics"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "Meta AI Marketing Strategy",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/meta_ai_strategy.md",
+      "tags": [
+        "meta",
+        "ad-optimization",
+        "audience",
+        "creative"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "NeuroGym Neuromarketing Principles",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/neurogym_neuromarketing.md",
+      "tags": [
+        "neuromarketing",
+        "psychology",
+        "attention",
+        "motivation"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "Reforge Growth Loops",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/reforge_growth_loops.md",
+      "tags": [
+        "growth",
+        "experimentation",
+        "loops",
+        "balfour"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "Skai ROI Optimization Framework",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/skai_roi_optimization.md",
+      "tags": [
+        "skai",
+        "roi",
+        "cross-channel",
+        "optimization"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "Smartly Creative AI Optimization",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/smartly_creative_ai.md",
+      "tags": [
+        "smartly",
+        "creative",
+        "personalization",
+        "ads"
+      ],
+      "version": "1.0.0"
+    },
+    {
       "name": "O3 Release Checklist",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/release_checklist_v3.5.md",
       "tags": [
@@ -291,373 +379,6 @@
       ],
       "version": "3.5.7",
       "type": "documentation"
-    },
-    {
-      "name": "A2A Protocol",
-      "link": "https://github.com/AutogenStudio/autogen",
-      "description": "The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.",
-      "used_by": [
-        "ConfigAgent",
-        "CampaignAgent"
-      ],
-      "tags": [
-        "coordination",
-        "orchestration"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "AI Fairness 360 Toolkit",
-      "link": "https://aif360.readthedocs.io/",
-      "description": "IBM's AI Fairness 360 Toolkit provides metrics and algorithms to detect and mitigate bias in AI models.",
-      "used_by": [
-        "AnalyticsAgent",
-        "ConfigAgent"
-      ],
-      "tags": [
-        "bias",
-        "scoring"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Airtable API",
-      "link": "https://airtable.com/developers/web/api/introduction",
-      "description": "Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.",
-      "used_by": [
-        "ResearchAgent",
-        "ConfigAgent"
-      ],
-      "tags": [
-        "memory",
-        "coordination"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Amplitude Docs",
-      "link": "https://www.docs.developers.amplitude.com",
-      "description": "Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights. See [Reforge Growth Loops](../../performance_marketing/reforge_growth_loops.md) for marketing strategies that complement Amplitude metrics.",
-      "used_by": [
-        "AnalyticsAgent",
-        "OptimizationAgent"
-      ],
-      "tags": [
-        "analytics",
-        "performance"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Anthropic Prompting Guide",
-      "link": "https://docs.anthropic.com/claude/prompting-best-practices",
-      "description": "Anthropic's guide outlines best practices for constructing prompts with Claude, including chain-of-thought, embedding usage, and framing techniques.",
-      "used_by": [
-        "ResearchAgent",
-        "ContentAgent"
-      ],
-      "tags": [
-        "prompting",
-        "grounding"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Apple ML APIs",
-      "link": "https://developer.apple.com/machine-learning/",
-      "description": "Apple's machine learning APIs offer tools for deploying models on iOS and macOS with privacy-focused approaches.",
-      "used_by": [
-        "EngagementAgent"
-      ],
-      "tags": [
-        "fallback",
-        "on-device"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Claude API Docs",
-      "link": "https://docs.anthropic.com",
-      "description": "Official documentation for the Anthropic Claude API, covering endpoints, prompt guidelines, and response formats.",
-      "used_by": [
-        "ContentAgent",
-        "ConfigAgent",
-        "ResearchAgent"
-      ],
-      "tags": [
-        "prompting",
-        "grounding",
-        "fallback"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "CognitiveLoad Design (NNG)",
-      "link": "https://www.nngroup.com/topic/cognitive-load/",
-      "description": "Nielsen Norman Group's research on cognitive load informs how to design experiences that account for user attention and effort.",
-      "used_by": [
-        "EngagementAgent",
-        "ContentAgent"
-      ],
-      "tags": [
-        "behavioral",
-        "prompting"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "DeepMind Gopher Prompt Lab",
-      "link": "https://arxiv.org/abs/2202.11382",
-      "description": "The Gopher Prompt Lab paper explores methods for reasoning, scoring, and prompt mutation to achieve better LLM responses.",
-      "used_by": [
-        "CampaignAgent",
-        "ConfigAgent"
-      ],
-      "tags": [
-        "reflection",
-        "mutation"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "FLAN-T5 Prompt Patterns",
-      "link": "https://github.com/google-research/FLAN",
-      "description": "FLAN-T5 examples highlight cross-task generalization and demonstrate how prompts map to various downstream tasks.",
-      "used_by": [
-        "ResearchAgent"
-      ],
-      "tags": [
-        "task",
-        "grounding"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "FastAPI Docs",
-      "link": "https://fastapi.tiangolo.com/",
-      "description": "FastAPI is a modern web framework for building APIs with Python. It provides asynchronous request handling and automatic documentation.",
-      "used_by": [
-        "All",
-        "agents"
-      ],
-      "tags": [
-        "api",
-        "coordination"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "GDPR Prompting Compliance",
-      "link": "https://gdpr.eu",
-      "description": "GDPR resources provide guidelines on data privacy and consent requirements that impact conversational AI and user messaging.",
-      "used_by": [
-        "EngagementAgent",
-        "ConfigAgent"
-      ],
-      "tags": [
-        "compliance",
-        "constraints"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Google Docs API",
-      "link": "https://developers.google.com/docs",
-      "description": "Google Docs API enables structured document creation, formatting, and semantic content generation from code. It pairs well with the [Prompt Kernel](../../prompt/prompt_kernel_v3.5.md) when storing conversation state.",
-      "used_by": [
-        "ResearchAgent",
-        "ConfigAgent",
-        "ContentAgent"
-      ],
-      "tags": [
-        "memory",
-        "grounding",
-        "coordination"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Helm Charts (K8s)",
-      "link": "https://helm.sh/docs/",
-      "description": "Helm is a package manager for Kubernetes that simplifies deployment of complex applications using chart templates.",
-      "used_by": [
-        "ConfigAgent",
-        "Infra"
-      ],
-      "tags": [
-        "deployment",
-        "CI/CD"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "LangChain Docs",
-      "link": "https://docs.langchain.com",
-      "description": "LangChain provides modular utilities for building language model powered applications. ADK agents can leverage these components for chaining tasks and managing context windows.",
-      "used_by": [
-        "ConfigAgent",
-        "ResearchAgent"
-      ],
-      "tags": [
-        "prompting",
-        "coordination",
-        "memory"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "MCP Server API",
-      "link": "https://mcp-docs.readthedocs.io/",
-      "description": "The MCP Server API exposes endpoints for storing, retrieving, and managing agent data across distributed services.",
-      "used_by": [
-        "ConfigAgent",
-        "Infra"
-      ],
-      "tags": [
-        "orchestration",
-        "memory"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "MLflow",
-      "link": "https://mlflow.org/docs/latest/index.html",
-      "description": "MLflow is a platform for managing the end-to-end machine learning lifecycle, including experiment tracking and model registry.",
-      "used_by": [
-        "AnalyticsAgent",
-        "OptimizationAgent"
-      ],
-      "tags": [
-        "prompt",
-        "lineage",
-        "tuning"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "OpenAI Cookbook",
-      "link": "https://github.com/openai/openai-cookbook",
-      "description": "The OpenAI Cookbook contains practical examples and code snippets for using OpenAI models effectively. It offers recipes for prompt engineering, embedding usage, and data pipelines.",
-      "used_by": [
-        "ResearchAgent",
-        "ContentAgent"
-      ],
-      "tags": [
-        "prompting",
-        "memory",
-        "fallback"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "OpenPrompt Evaluator",
-      "link": "https://github.com/thunlp/OpenPrompt",
-      "description": "OpenPrompt provides a framework for comparing prompt versions and evaluating language model outputs.",
-      "used_by": [
-        "ConfigAgent",
-        "PromptOps"
-      ],
-      "tags": [
-        "validation",
-        "scoring"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Ray Serve Docs",
-      "link": "https://docs.ray.io/en/latest/serve/",
-      "description": "Ray Serve provides scalable microservice orchestration for deploying machine learning models and agents.",
-      "used_by": [
-        "ConfigAgent",
-        "CampaignAgent"
-      ],
-      "tags": [
-        "orchestration",
-        "performance"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "TinyML / Edge AI",
-      "link": "https://www.tinyml.org/",
-      "description": "TinyML explores machine learning techniques for resource-constrained devices, enabling on-device inference and quick adaptation.",
-      "used_by": [
-        "OptimizationAgent",
-        "ConfigAgent"
-      ],
-      "tags": [
-        "adaptive",
-        "control",
-        "fallback"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Vertex AI Grounding",
-      "link": "https://cloud.google.com/vertex-ai/docs/generative-ai/grounding",
-      "description": "Vertex AI Grounding describes how to anchor generative outputs to trusted data sources using Google Cloud services.",
-      "used_by": [
-        "ResearchAgent",
-        "ContentAgent"
-      ],
-      "tags": [
-        "grounding",
-        "prompting"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "Weights & Biases Docs",
-      "link": "https://docs.wandb.ai/",
-      "description": "Weights & Biases provides experiment tracking and visualization tools for machine learning and prompt development.",
-      "used_by": [
-        "ConfigAgent",
-        "AnalyticsAgent"
-      ],
-      "tags": [
-        "CI",
-        "metrics",
-        "tuning"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
-    },
-    {
-      "name": "n8n Docs",
-      "link": "https://docs.n8n.io",
-      "description": "n8n is a workflow automation tool with a node-based interface and rich API. Its documentation provides guidelines for integrating external services.",
-      "used_by": [
-        "ConfigAgent",
-        "IntegrationAgent"
-      ],
-      "tags": [
-        "coordination",
-        "automation"
-      ],
-      "last_reviewed": "2025-05-30",
-      "type": "external"
     },
     {
       "name": "World Agent Integration Blueprint",
@@ -701,11 +422,899 @@
       ],
       "version": "3.5.7",
       "type": "documentation"
+    },
+    {
+      "name": "A2A Protocol",
+      "link": "https://github.com/AutogenStudio/autogen",
+      "description": "The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.",
+      "used_by": [
+        "ConfigAgent",
+        "CampaignAgent"
+      ],
+      "tags": [
+        "coordination",
+        "orchestration"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "A2A Protocol",
+      "link": "https://github.com/AutogenStudio/autogen",
+      "description": "The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.",
+      "used_by": [
+        "ConfigAgent",
+        "CampaignAgent"
+      ],
+      "tags": [
+        "coordination",
+        "orchestration"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "A2A Protocol",
+      "link": "https://github.com/AutogenStudio/autogen",
+      "description": "The A2A (Agent-to-Agent) protocol defines a standard for multi-agent communication and coordination. It enables reliable message passing and task delegation among autonomous agents.",
+      "used_by": [
+        "ConfigAgent",
+        "CampaignAgent"
+      ],
+      "tags": [
+        "coordination",
+        "orchestration"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "AI Fairness 360 Toolkit",
+      "link": "https://aif360.readthedocs.io/",
+      "description": "IBM's AI Fairness 360 Toolkit provides metrics and algorithms to detect and mitigate bias in AI models.",
+      "used_by": [
+        "AnalyticsAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "bias",
+        "scoring"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "AI Fairness 360 Toolkit",
+      "link": "https://aif360.readthedocs.io/",
+      "description": "IBM's AI Fairness 360 Toolkit provides metrics and algorithms to detect and mitigate bias in AI models.",
+      "used_by": [
+        "AnalyticsAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "bias",
+        "scoring"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Airtable API",
+      "link": "https://airtable.com/developers/web/api/introduction",
+      "description": "Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "memory",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Airtable API",
+      "link": "https://airtable.com/developers/web/api/introduction",
+      "description": "Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "memory",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Airtable API",
+      "link": "https://airtable.com/developers/web/api/introduction",
+      "description": "Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "memory",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Airtable API",
+      "link": "https://airtable.com/developers/web/api/introduction",
+      "description": "Airtable's API allows structured data storage with spreadsheet-like ease. ADK agents can use it to persist results and share records across workflows.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "memory",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Amplitude Docs",
+      "link": "https://www.docs.developers.amplitude.com",
+      "description": "Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "analytics",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Amplitude Docs",
+      "link": "https://www.docs.developers.amplitude.com",
+      "description": "Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights. See [Reforge Growth Loops](../../performance_marketing/reforge_growth_loops.md) for marketing strategies that complement Amplitude metrics.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "analytics",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Amplitude Docs",
+      "link": "https://www.docs.developers.amplitude.com",
+      "description": "Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "analytics",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Amplitude Docs",
+      "link": "https://www.docs.developers.amplitude.com",
+      "description": "Amplitude provides product analytics for measuring user engagement and conversion. Their developer docs outline APIs for ingesting events and querying insights.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "analytics",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Anthropic Prompting Guide",
+      "link": "https://docs.anthropic.com/claude/prompting-best-practices",
+      "description": "Anthropic's guide outlines best practices for constructing prompts with Claude, including chain-of-thought, embedding usage, and framing techniques.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "prompting",
+        "grounding"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Anthropic Prompting Guide",
+      "link": "https://docs.anthropic.com/claude/prompting-best-practices",
+      "description": "Anthropic's guide outlines best practices for constructing prompts with Claude, including chain-of-thought, embedding usage, and framing techniques.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "prompting",
+        "grounding"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Apple ML APIs",
+      "link": "https://developer.apple.com/machine-learning/",
+      "description": "Apple's machine learning APIs offer tools for deploying models on iOS and macOS with privacy-focused approaches.",
+      "used_by": [
+        "EngagementAgent"
+      ],
+      "tags": [
+        "fallback",
+        "on-device"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Apple ML APIs",
+      "link": "https://developer.apple.com/machine-learning/",
+      "description": "Apple's machine learning APIs offer tools for deploying models on iOS and macOS with privacy-focused approaches.",
+      "used_by": [
+        "EngagementAgent"
+      ],
+      "tags": [
+        "fallback",
+        "on-device"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Apple ML APIs",
+      "link": "https://developer.apple.com/machine-learning/",
+      "description": "Apple's machine learning APIs offer tools for deploying models on iOS and macOS with privacy-focused approaches.",
+      "used_by": [
+        "EngagementAgent"
+      ],
+      "tags": [
+        "fallback",
+        "on-device"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Claude API Docs",
+      "link": "https://docs.anthropic.com",
+      "description": "Official documentation for the Anthropic Claude API, covering endpoints, prompt guidelines, and response formats.",
+      "used_by": [
+        "ContentAgent",
+        "ConfigAgent",
+        "ResearchAgent"
+      ],
+      "tags": [
+        "prompting",
+        "grounding",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Claude API Docs",
+      "link": "https://docs.anthropic.com",
+      "description": "Official documentation for the Anthropic Claude API, covering endpoints, prompt guidelines, and response formats.",
+      "used_by": [
+        "ContentAgent",
+        "ConfigAgent",
+        "ResearchAgent"
+      ],
+      "tags": [
+        "prompting",
+        "grounding",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "CognitiveLoad Design (NNG)",
+      "link": "https://www.nngroup.com/topic/cognitive-load/",
+      "description": "Nielsen Norman Group's research on cognitive load informs how to design experiences that account for user attention and effort.",
+      "used_by": [
+        "EngagementAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "behavioral",
+        "prompting"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "CognitiveLoad Design (NNG)",
+      "link": "https://www.nngroup.com/topic/cognitive-load/",
+      "description": "Nielsen Norman Group's research on cognitive load informs how to design experiences that account for user attention and effort.",
+      "used_by": [
+        "EngagementAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "behavioral",
+        "prompting"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "DeepMind Gopher Prompt Lab",
+      "link": "https://arxiv.org/abs/2202.11382",
+      "description": "The Gopher Prompt Lab paper explores methods for reasoning, scoring, and prompt mutation to achieve better LLM responses.",
+      "used_by": [
+        "CampaignAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "reflection",
+        "mutation"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "DeepMind Gopher Prompt Lab",
+      "link": "https://arxiv.org/abs/2202.11382",
+      "description": "The Gopher Prompt Lab paper explores methods for reasoning, scoring, and prompt mutation to achieve better LLM responses.",
+      "used_by": [
+        "CampaignAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "reflection",
+        "mutation"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "FLAN-T5 Prompt Patterns",
+      "link": "https://github.com/google-research/FLAN",
+      "description": "FLAN-T5 examples highlight cross-task generalization and demonstrate how prompts map to various downstream tasks.",
+      "used_by": [
+        "ResearchAgent"
+      ],
+      "tags": [
+        "task",
+        "grounding"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "FLAN-T5 Prompt Patterns",
+      "link": "https://github.com/google-research/FLAN",
+      "description": "FLAN-T5 examples highlight cross-task generalization and demonstrate how prompts map to various downstream tasks.",
+      "used_by": [
+        "ResearchAgent"
+      ],
+      "tags": [
+        "task",
+        "grounding"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "FastAPI Docs",
+      "link": "https://fastapi.tiangolo.com/",
+      "description": "FastAPI is a modern web framework for building APIs with Python. It provides asynchronous request handling and automatic documentation.",
+      "used_by": [
+        "All",
+        "agents"
+      ],
+      "tags": [
+        "api",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "FastAPI Docs",
+      "link": "https://fastapi.tiangolo.com/",
+      "description": "FastAPI is a modern web framework for building APIs with Python. It provides asynchronous request handling and automatic documentation.",
+      "used_by": [
+        "All",
+        "agents"
+      ],
+      "tags": [
+        "api",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "GDPR Prompting Compliance",
+      "link": "https://gdpr.eu",
+      "description": "GDPR resources provide guidelines on data privacy and consent requirements that impact conversational AI and user messaging.",
+      "used_by": [
+        "EngagementAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "compliance",
+        "constraints"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "GDPR Prompting Compliance",
+      "link": "https://gdpr.eu",
+      "description": "GDPR resources provide guidelines on data privacy and consent requirements that impact conversational AI and user messaging.",
+      "used_by": [
+        "EngagementAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "compliance",
+        "constraints"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Google Docs API",
+      "link": "https://developers.google.com/docs",
+      "description": "Google Docs API enables structured document creation, formatting, and semantic content generation from code. In the context of ADK agent workflows, it can act as both a **semantic memory channel** and **document-based orchestration endpoint**.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "memory",
+        "grounding",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Google Docs API",
+      "link": "https://developers.google.com/docs",
+      "description": "Google Docs API enables structured document creation, formatting, and semantic content generation from code. It pairs well with the [Prompt Kernel](../../prompt/prompt_kernel_v3.5.md) when storing conversation state.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "memory",
+        "grounding",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Google Docs API",
+      "link": "https://developers.google.com/docs",
+      "description": "Google Docs API enables structured document creation, formatting, and semantic content generation from code. In the context of ADK agent workflows, it can act as both a **semantic memory channel** and **document-based orchestration endpoint**.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "memory",
+        "grounding",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Google Docs API",
+      "link": "https://developers.google.com/docs",
+      "description": "Google Docs API enables structured document creation, formatting, and semantic content generation from code. In the context of ADK agent workflows, it can act as both a **semantic memory channel** and **document-based orchestration endpoint**.",
+      "used_by": [
+        "ResearchAgent",
+        "ConfigAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "memory",
+        "grounding",
+        "coordination"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Helm Charts (K8s)",
+      "link": "https://helm.sh/docs/",
+      "description": "Helm is a package manager for Kubernetes that simplifies deployment of complex applications using chart templates.",
+      "used_by": [
+        "ConfigAgent",
+        "Infra"
+      ],
+      "tags": [
+        "deployment",
+        "CI/CD"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Helm Charts (K8s)",
+      "link": "https://helm.sh/docs/",
+      "description": "Helm is a package manager for Kubernetes that simplifies deployment of complex applications using chart templates.",
+      "used_by": [
+        "ConfigAgent",
+        "Infra"
+      ],
+      "tags": [
+        "deployment",
+        "CI/CD"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "LangChain Docs",
+      "link": "https://docs.langchain.com",
+      "description": "LangChain provides modular utilities for building language model powered applications. ADK agents can leverage these components for chaining tasks and managing context windows.",
+      "used_by": [
+        "ConfigAgent",
+        "ResearchAgent"
+      ],
+      "tags": [
+        "prompting",
+        "coordination",
+        "memory"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "LangChain Docs",
+      "link": "https://docs.langchain.com",
+      "description": "LangChain provides modular utilities for building language model powered applications. ADK agents can leverage these components for chaining tasks and managing context windows.",
+      "used_by": [
+        "ConfigAgent",
+        "ResearchAgent"
+      ],
+      "tags": [
+        "prompting",
+        "coordination",
+        "memory"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "MCP Server API",
+      "link": "https://mcp-docs.readthedocs.io/",
+      "description": "The MCP Server API exposes endpoints for storing, retrieving, and managing agent data across distributed services.",
+      "used_by": [
+        "ConfigAgent",
+        "Infra"
+      ],
+      "tags": [
+        "orchestration",
+        "memory"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "MCP Server API",
+      "link": "https://mcp-docs.readthedocs.io/",
+      "description": "The MCP Server API exposes endpoints for storing, retrieving, and managing agent data across distributed services.",
+      "used_by": [
+        "ConfigAgent",
+        "Infra"
+      ],
+      "tags": [
+        "orchestration",
+        "memory"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "MLflow",
+      "link": "https://mlflow.org/docs/latest/index.html",
+      "description": "MLflow is a platform for managing the end-to-end machine learning lifecycle, including experiment tracking and model registry.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "prompt",
+        "lineage",
+        "tuning"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "MLflow",
+      "link": "https://mlflow.org/docs/latest/index.html",
+      "description": "MLflow is a platform for managing the end-to-end machine learning lifecycle, including experiment tracking and model registry.",
+      "used_by": [
+        "AnalyticsAgent",
+        "OptimizationAgent"
+      ],
+      "tags": [
+        "prompt",
+        "lineage",
+        "tuning"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "OpenAI Cookbook",
+      "link": "https://github.com/openai/openai-cookbook",
+      "description": "The OpenAI Cookbook contains practical examples and code snippets for using OpenAI models effectively. It offers recipes for prompt engineering, embedding usage, and data pipelines.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "prompting",
+        "memory",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "OpenAI Cookbook",
+      "link": "https://github.com/openai/openai-cookbook",
+      "description": "The OpenAI Cookbook contains practical examples and code snippets for using OpenAI models effectively. It offers recipes for prompt engineering, embedding usage, and data pipelines.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "prompting",
+        "memory",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "OpenPrompt Evaluator",
+      "link": "https://github.com/thunlp/OpenPrompt",
+      "description": "OpenPrompt provides a framework for comparing prompt versions and evaluating language model outputs.",
+      "used_by": [
+        "ConfigAgent",
+        "PromptOps"
+      ],
+      "tags": [
+        "validation",
+        "scoring"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "OpenPrompt Evaluator",
+      "link": "https://github.com/thunlp/OpenPrompt",
+      "description": "OpenPrompt provides a framework for comparing prompt versions and evaluating language model outputs.",
+      "used_by": [
+        "ConfigAgent",
+        "PromptOps"
+      ],
+      "tags": [
+        "validation",
+        "scoring"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "OpenPrompt Evaluator",
+      "link": "https://github.com/thunlp/OpenPrompt",
+      "description": "OpenPrompt provides a framework for comparing prompt versions and evaluating language model outputs.",
+      "used_by": [
+        "ConfigAgent",
+        "PromptOps"
+      ],
+      "tags": [
+        "validation",
+        "scoring"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Ray Serve Docs",
+      "link": "https://docs.ray.io/en/latest/serve/",
+      "description": "Ray Serve provides scalable microservice orchestration for deploying machine learning models and agents.",
+      "used_by": [
+        "ConfigAgent",
+        "CampaignAgent"
+      ],
+      "tags": [
+        "orchestration",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Ray Serve Docs",
+      "link": "https://docs.ray.io/en/latest/serve/",
+      "description": "Ray Serve provides scalable microservice orchestration for deploying machine learning models and agents.",
+      "used_by": [
+        "ConfigAgent",
+        "CampaignAgent"
+      ],
+      "tags": [
+        "orchestration",
+        "performance"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "TinyML / Edge AI",
+      "link": "https://www.tinyml.org/",
+      "description": "TinyML explores machine learning techniques for resource-constrained devices, enabling on-device inference and quick adaptation.",
+      "used_by": [
+        "OptimizationAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "adaptive",
+        "control",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "TinyML / Edge AI",
+      "link": "https://www.tinyml.org/",
+      "description": "TinyML explores machine learning techniques for resource-constrained devices, enabling on-device inference and quick adaptation.",
+      "used_by": [
+        "OptimizationAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "adaptive",
+        "control",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "TinyML / Edge AI",
+      "link": "https://www.tinyml.org/",
+      "description": "TinyML explores machine learning techniques for resource-constrained devices, enabling on-device inference and quick adaptation.",
+      "used_by": [
+        "OptimizationAgent",
+        "ConfigAgent"
+      ],
+      "tags": [
+        "adaptive",
+        "control",
+        "fallback"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Vertex AI Grounding",
+      "link": "https://cloud.google.com/vertex-ai/docs/generative-ai/grounding",
+      "description": "Vertex AI Grounding describes how to anchor generative outputs to trusted data sources using Google Cloud services.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "grounding",
+        "prompting"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Vertex AI Grounding",
+      "link": "https://cloud.google.com/vertex-ai/docs/generative-ai/grounding",
+      "description": "Vertex AI Grounding describes how to anchor generative outputs to trusted data sources using Google Cloud services.",
+      "used_by": [
+        "ResearchAgent",
+        "ContentAgent"
+      ],
+      "tags": [
+        "grounding",
+        "prompting"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Weights & Biases Docs",
+      "link": "https://docs.wandb.ai/",
+      "description": "Weights & Biases provides experiment tracking and visualization tools for machine learning and prompt development.",
+      "used_by": [
+        "ConfigAgent",
+        "AnalyticsAgent"
+      ],
+      "tags": [
+        "CI",
+        "metrics",
+        "tuning"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "Weights & Biases Docs",
+      "link": "https://docs.wandb.ai/",
+      "description": "Weights & Biases provides experiment tracking and visualization tools for machine learning and prompt development.",
+      "used_by": [
+        "ConfigAgent",
+        "AnalyticsAgent"
+      ],
+      "tags": [
+        "CI",
+        "metrics",
+        "tuning"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "n8n Docs",
+      "link": "https://docs.n8n.io",
+      "description": "n8n is a workflow automation tool with a node-based interface and rich API. Its documentation provides guidelines for integrating external services.",
+      "used_by": [
+        "ConfigAgent",
+        "IntegrationAgent"
+      ],
+      "tags": [
+        "coordination",
+        "automation"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
+    },
+    {
+      "name": "n8n Docs",
+      "link": "https://docs.n8n.io",
+      "description": "n8n is a workflow automation tool with a node-based interface and rich API. Its documentation provides guidelines for integrating external services.",
+      "used_by": [
+        "ConfigAgent",
+        "IntegrationAgent"
+      ],
+      "tags": [
+        "coordination",
+        "automation"
+      ],
+      "last_reviewed": "2025-06-03",
+      "type": "external"
     }
   ],
   "metadata": {
     "include_web": true,
-    "last_updated": "2025-06-01",
+    "last_updated": "2025-06-03",
     "version": "3.5.7"
   }
 }


### PR DESCRIPTION
## Summary
- add performance marketing pages to source index
- rebuild `docs/source_index.json`

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py` *(fails: network access required)*


------
https://chatgpt.com/codex/tasks/task_b_683e8ffae5588333aba23eba0a4be4d1