### PR TITLE
Add prompt version check to CI

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -174,3 +174,15 @@ jobs:
             echo "Missing v3.4 entry in prompt genome."
             exit 1
           fi
+
+      - name: Verify prompt_version matches VERSION
+        run: |
+          echo "Checking prompt_version consistency..."
+          SETTINGS_VERSION=$(grep -oP '^prompt_version:\s*\K[0-9]+\.[0-9]+\.[0-9]+' config/settings.yaml)
+          FILE_VERSION=$(tr -d '[:space:]' < VERSION)
+          if [ "$SETTINGS_VERSION" != "$FILE_VERSION" ]; then
+            echo "❌ prompt_version mismatch: settings.yaml ($SETTINGS_VERSION) vs VERSION ($FILE_VERSION)"
+            exit 1
+          else
+            echo "✅ prompt_version $SETTINGS_VERSION matches VERSION"
+          fi


### PR DESCRIPTION
## Summary
- verify that `prompt_version` in `config/settings.yaml` matches `VERSION`

## Testing
- `npm ci --omit=optional`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq` and `yamllint` validation scripts
- `python3 scripts/refresh_link_cache.py`
- `grep` and curl broken link check *(fails: README.md:https://blog.hubspot.com/marketing/ai-marketing-strategy)*

------
https://chatgpt.com/codex/tasks/task_b_6844b35bacfc833397e999f1da0a9c38