### PR TITLE
Update bump_version to sync prompt settings

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -12,6 +12,14 @@ grep -rl "v${old}" docs | xargs sed -i "s/v${old}/v${new}/g"
 sed -i "s/${old}/${new}/g" docs/source_index.json
 echo "${new}" > VERSION
 
+# Update prompt version in settings.yaml
+sed -i "s/^prompt_version: .*/prompt_version: ${new}/" config/settings.yaml
+
+# Update meta evaluation if old version referenced without leading 'v'
+if [ -f docs/meta/meta_evaluation.json ]; then
+  sed -i "s/${old}/${new}/g" docs/meta/meta_evaluation.json
+fi
+
 # Update changelog placeholder if present
 if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
   today=$(date +%Y-%m-%d)


### PR DESCRIPTION
## Summary
- update bump_version.sh to also bump prompt_version in config
- update bump_version.sh to modify meta_evaluation.json when present

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`


------
https://chatgpt.com/codex/tasks/task_b_6844b6e10af883339f246ca1bd230904