### PR TITLE
test: ensure metadata sections present

### DIFF
--- a/tests/test_meta_json.py
+++ b/tests/test_meta_json.py
@@ -1,0 +1,26 @@
+import unittest
+import json
+
+class TestMetaEvaluationFile(unittest.TestCase):
+    def test_required_sections_present(self):
+        with open('docs/meta/meta_evaluation.json', 'r') as f:
+            data = json.load(f)
+        self.assertIn('evaluation_metrics', data)
+        self.assertIn('evaluation_workflow', data)
+        self.assertIn('version_history', data)
+
+class TestPromptGenomeFile(unittest.TestCase):
+    def test_active_version_present(self):
+        with open('VERSION') as vf:
+            version = vf.read().strip()
+        with open('docs/meta/prompt_genome.json', 'r') as f:
+            genome = json.load(f)
+        prompts = genome.get('prompt_genome', {}).get('prompts', [])
+        found = any(
+            p.get('status') == 'active' and version in (p.get('id', '') + p.get('name', ''))
+            for p in prompts
+        )
+        self.assertTrue(found, f'Active prompt for version {version} not found')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# 🚀 Pull Request Summary - v3.5.7

## 📋 Description of Changes
- Added new unit tests verifying structure of `meta_evaluation.json` and `prompt_genome.json`

---

## 🗂 Affected Files (v3.5.7)

### Core Files
- [ ] `docs/prompt/prompt_kernel_v3.5.md`
- [ ] `docs/meta/prompt_evolution_log/v3.5.yaml`
- [ ] `docs/meta/meta_evaluation.json`

### Test Files
- [x] `tests/golden_prompts/test_prompt_coordinator.md`
- [x] `tests/golden_prompts/test_memory_reflection.md`
- [x] `tests/golden_prompts/test_kpi_optimization.md`
- [x] `tests/test_meta_json.py`

### Supporting Files
- [ ] `docs/source_index.json`
- [ ] `CHANGELOG.md`
- [ ] `README.md`

### CI/CD
- [ ] `.github/workflows/validate_repo.yml`
- [ ] `.github/pull_request_template.md`

---

## 🧪 Golden Prompt Integration
- [ ] Added test_prompt_coordinator.md to `/tests/golden_prompts/`
- [ ] Added test_memory_reflection.md to `/tests/golden_prompts/`
- [ ] Added test_kpi_optimization.md to `/tests/golden_prompts/`
- [ ] CI configured to detect and validate golden prompts
- [ ] Golden prompts align with v3.5.7 kernel strategy

---

## ✅ Validation Checklist
- [x] No `TODO:` or `Coming soon` remaining
- [ ] Links (internal/external) validated *(fails due to network restrictions)*
- [ ] `source_index.json` updated if new `.md` was added
- [ ] `CHANGELOG.md` updated with version bump
- [ ] PR title follows format: `feat:` `fix:` `chore:` etc.
- [x] Golden prompts pass validation checks
- [x] All tests are passing

---

## 🧠 Notes & Context (optional)
N/A

------
https://chatgpt.com/codex/tasks/task_b_6844cbcaf23883338c3823e59ab74d62