### PR TITLE
Fix duplicate version entry

### DIFF
--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -181,10 +181,6 @@
     {
       "tag": "v3.5.7",
       "notes": "async event bus, logging and example workflow"
-    },
-    {
-      "tag": "v3.5.7",
-      "notes": "marketing platform integrations and metrics pipeline"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- remove repeated `v3.5.7` under `docs/meta/prompt_genome.json`

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `python3 scripts/refresh_link_cache.py`
- `version=$(jq -r '.versions[] | select(.tag=="v3.4")' docs/meta/prompt_genome.json)`
- `SETTINGS_VERSION=$(grep -oP '^prompt_version:\s*\K[0-9]+\.[0-9]+\.[0-9]+' config/settings.yaml)`
- `FILE_VERSION=$(tr -d '[:space:]' < VERSION)`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `while read -r url; do curl ...` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_b_6844d187a4488333a83f981a7dc178bb