### PR TITLE
Remove duplicate v3.5.7 from prompt genome

### DIFF
--- a/docs/meta/prompt_genome.json
+++ b/docs/meta/prompt_genome.json
@@ -177,10 +177,6 @@
     {
       "tag": "v3.5.6",
       "notes": "core utilities added and agents restructured"
-    },
-    {
-      "tag": "v3.5.7",
-      "notes": "async event bus, logging and example workflow"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- drop repeated v3.5.7 release block from `docs/meta/prompt_genome.json`

## Testing
- `jq . docs/meta/prompt_genome.json`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `for file in tests/golden_prompts/*.md; do ... done`
- `version=$(jq -r '.versions[] | select(.tag=="v3.4")' docs/meta/prompt_genome.json)`
- `SETTINGS_VERSION=$(grep -oP '^prompt_version:\s*\K[0-9]+\.[0-9]+\.[0-9]+' config/settings.yaml)`

------
https://chatgpt.com/codex/tasks/task_b_6844e06e95848333a5fe272a87138fd0