### PR TITLE
Update legacy map for v3.5.7

### DIFF
--- a/docs/meta/legacy_map.md
+++ b/docs/meta/legacy_map.md
@@ -5,9 +5,9 @@ This document tracks the migration and deprecation of previous versions of the O
 ## Version History
 
 ### Current Version
-- **v3.5.1** (2025-05-23)
+- **v3.5.7** (2025-06-01)
   - Location: `docs/prompt/prompt_kernel_v3.5.md`
-  - Patch update adding simulation and evaluation sections
+  - Patch release with AsyncEventBus, logging utilities, and expanded examples
 - **v3.5.0** (2025-05-22)
   - Location: `docs/prompt/prompt_kernel_v3.5.md`
   - Key Features:


### PR DESCRIPTION
## Summary
- update legacy mapping doc to reference v3.5.7

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- check required files exist
- verify README and CHANGELOG versions match
- validate golden prompts
- `python3 scripts/refresh_link_cache.py`

------
https://chatgpt.com/codex/tasks/task_b_6844e5a8e8648333ba61193ef14e5fa5