### PR TITLE
Use offline link check in workflow

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -145,21 +145,9 @@ jobs:
           done
 
 
-      - name: Broken Link Check (Basic)
-        if: github.event_name == 'push'  # Only run on push to reduce API calls
+      - name: Offline Link Check
         run: |
-          echo "Checking for broken links..."
-          grep -rEo 'https?://[^") >]+' docs/ README.md | \
-            grep -v 'localhost\|example\.com' | \
-            sort -u | \
-            while read -r url; do
-              if ! curl -s --head --location --max-time 10 --fail "$url" >/dev/null; then
-                echo "❌ Broken link: $url"
-                exit 1
-              else
-                echo "✅ Link OK: $url"
-              fi
-            done
+          bash scripts/offline_link_check.sh
           test -f docs/performance_marketing/reforge_growth_loops.md
           test -f docs/legacy/prompt/prompt_kernel_v3.4.md
           test -f docs/meta/prompt_genome.json


### PR DESCRIPTION
## Summary
- replace the curl-based link checker with `offline_link_check.sh`

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh` *(fails: cached status 0)*
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/setup_env.sh`

------
https://chatgpt.com/codex/tasks/task_b_6844e7cd21a88333a110419aa37c986b