### PR TITLE
Add evaluation utility with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository powers the O3 Deep Research initiative, an advanced AI-powered m
 - [Prompt Kernel v3.5](docs/prompt/prompt_kernel_v3.5.md) - Core prompt engineering framework (latest)
 - [Prompt Evolution Log](docs/meta/prompt_evolution_log/v3.5.yaml) - Version history and changes
 - [Meta Evaluation](docs/meta/meta_evaluation.json) - Evaluation framework and metrics
+- [Meta Evaluation Usage](docs/meta/meta_evaluation.md) - How to compute weighted scores
 - [Evaluation Results](docs/meta/evaluation_results.json) - Scores recorded for each release
 - [GitHub Integration Guide](docs/github_chatgpt_integration.md) - Connect this repository to ChatGPT
 - [O3 Integration Guide](docs/integration_guide_o3.md) - Setup and orchestration steps

--- a/docs/meta/meta_evaluation.md
+++ b/docs/meta/meta_evaluation.md
@@ -1,0 +1,16 @@
+# Meta Evaluation Usage
+
+The evaluation framework defined in `meta_evaluation.json` assigns a weight to each metric. To compute an overall score programmatically:
+
+```python
+from src.core.evaluation import evaluate
+
+score = evaluate({
+    "clarity": 5,
+    "completeness": 4,
+    "alignment": 4,
+    "efficiency": 3,
+})
+```
+
+The `evaluate` function loads the weights from `meta_evaluation.json` and returns the weighted average. Metrics not defined in the JSON are ignored.

--- a/src/core/evaluation.py
+++ b/src/core/evaluation.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+
+def _load_meta_evaluation() -> dict:
+    """Load evaluation metadata from JSON."""
+    path = Path(__file__).resolve().parents[2] / "docs" / "meta" / "meta_evaluation.json"
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+META_EVALUATION = _load_meta_evaluation()
+
+
+def evaluate(metrics: dict[str, float]) -> float:
+    """Compute a weighted score based on provided metrics.
+
+    Parameters
+    ----------
+    metrics: dict[str, float]
+        Mapping of metric id to numeric score.
+
+    Returns
+    -------
+    float
+        Weighted evaluation score. Returns 0.0 if no weights match.
+    """
+    weights = {m["id"]: m.get("weight", 0.0) for m in META_EVALUATION.get("evaluation_metrics", [])}
+    weighted_sum = 0.0
+    total_weight = 0.0
+    for name, score in metrics.items():
+        weight = weights.get(name)
+        if weight:
+            weighted_sum += score * weight
+            total_weight += weight
+    return weighted_sum / total_weight if total_weight else 0.0

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,25 @@
+import unittest
+from src.core.evaluation import evaluate
+
+class TestEvaluation(unittest.TestCase):
+    def test_weighted_score_full(self):
+        metrics = {
+            "clarity": 5,
+            "completeness": 3,
+            "alignment": 4,
+            "efficiency": 2,
+        }
+        score = evaluate(metrics)
+        self.assertAlmostEqual(score, 3.5)
+
+    def test_weighted_score_partial(self):
+        metrics = {
+            "clarity": 4,
+            "efficiency": 4,
+        }
+        score = evaluate(metrics)
+        # Only clarity and efficiency weights (0.25 each) should be considered
+        self.assertAlmostEqual(score, 4.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement evaluation helper loading meta_evaluation.json
- document how to use the evaluate function
- expose evaluation documentation in README
- test weighted scoring

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include='*.md' --include='*.yaml' --include='*.yml' --exclude-dir=legacy`
- `bash scripts/offline_link_check.sh`
- `python3 scripts/refresh_link_cache.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844e948c2948333ae44598d40283f56