### PR TITLE
fix: update link regex and cache

### DIFF
--- a/docs/link_cache.txt
+++ b/docs/link_cache.txt
@@ -4,8 +4,6 @@ https://arxiv.org/abs/2202.11382 0
 https://cloud.google.com/vertex-ai/docs/generative-ai/grounding 0
 https://developer.apple.com/machine-learning/ 0
 https://developers.google.com/docs 0
-https://developers.google.com/docs
-**Relevance:** 0
 https://docs.anthropic.com 0
 https://docs.anthropic.com/claude/prompting-best-practices 0
 https://docs.langchain.com 0
@@ -22,7 +20,5 @@ https://helm.sh/docs/ 0
 https://mcp-docs.readthedocs.io/ 0
 https://mlflow.org/docs/latest/index.html 0
 https://www.docs.developers.amplitude.com 0
-https://www.docs.developers.amplitude.com
-**Relevance:** 0
 https://www.nngroup.com/topic/cognitive-load/ 0
 https://www.tinyml.org/ 0

--- a/scripts/offline_link_check.sh
+++ b/scripts/offline_link_check.sh
@@ -7,7 +7,7 @@ if [ ! -f "$CACHE_FILE" ]; then
   echo "Cache file $CACHE_FILE not found" >&2
   exit 1
 fi
-links=$(grep -rhoE 'https?://[^ )]+' docs/external | sort -u)
+links=$(grep -rhoE 'https?://[^ )\\n]+' docs/external | sort -u)
 for link in $links; do
   status=$(grep -F "$link" "$CACHE_FILE" | head -n 1 | awk '{print $2}')
   if [ -z "$status" ]; then

--- a/scripts/refresh_link_cache.py
+++ b/scripts/refresh_link_cache.py
@@ -15,7 +15,7 @@ def collect_links():
             if not name.endswith('.md'):
                 continue
             with open(os.path.join(dirpath, name), 'r', encoding='utf-8') as f:
-                for match in re.findall(r'https?://[^ )]+', f.read()):
+                for match in re.findall(r'https?://[^\s)]+', f.read()):
                     links.add(match)
     return sorted(links)
 


### PR DESCRIPTION
## 📋 Description of Changes
- refine regex in `offline_link_check.sh` to avoid capturing newlines
- stop link collection in `refresh_link_cache.py` at whitespace
- regenerate `docs/link_cache.txt` using the updated script

## ✅ Validation Checklist
- [x] `markdownlint` passed
- [x] JSON and YAML validated
- [x] No `TODO` or `Coming soon` left in docs
- [x] Golden prompts validated
- [ ] All tests passing *(offline link check fails due to cached status 0)*


------
https://chatgpt.com/codex/tasks/task_b_6844edb355bc8333a40a5cf5476c18c5