### PR TITLE
Fix placeholder snippet in amplitude docs

### DIFF
--- a/docs/external/analytics/amplitude_docs.md
+++ b/docs/external/analytics/amplitude_docs.md
@@ -20,5 +20,15 @@ Amplitude provides product analytics for measuring user engagement and conversio
 ## Example Code
 
 ```python
-# Example placeholder
+import json
+import requests
+
+API_KEY = "YOUR_API_KEY"
+events = [{"user_id": "user123", "event_type": "Button Clicked"}]
+
+requests.post(
+    "https://api.amplitude.com/2/httpapi",
+    headers={"Content-Type": "application/json"},
+    data=json.dumps({"api_key": API_KEY, "events": events}),
+)
 ```


### PR DESCRIPTION
## Summary
- replace placeholder code in `amplitude_docs.md` with API example

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `grep -RniE 'TODO:|Coming soon' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- required files exist
- version consistency check
- golden prompt validation
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- prompt genome version check
- prompt_version consistency check

Codex couldn't run `npm ci` due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6844f6238cd083338d15dccc55dd7c19