### PR TITLE
fix: update YAML validation command

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -58,12 +58,10 @@ jobs:
       - name: Validate YAML files
         run: |
           echo "Validating YAML files..."
+          CONFIG='{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
           find . -path ./node_modules -prune -o \(
             -name '*.yaml' -o -name '*.yml' \) -print0 |
-            xargs -0 yamllint -d '{
-              extends: default,
-              rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}
-            }'
+            xargs -0 yamllint -d "$CONFIG"
 
       - name: Check for TODO, Coming soon, or placeholder
         run: |


### PR DESCRIPTION
## Summary
- fix `Validate YAML files` in workflow to avoid newline parsing errors

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "!docs/legacy/**"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on all YAML files
- `bash scripts/offline_link_check.sh`
- `python3 scripts/refresh_link_cache.py` *(not committed)*
- `npm ci --omit=optional` *(fails: Forbidden - network access)*

------
https://chatgpt.com/codex/tasks/task_b_6844fb07dab48333aa9fa78b803cf69f