### PR TITLE
fix: correct YAML validation command

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -59,9 +59,8 @@ jobs:
         run: |
           echo "Validating YAML files..."
           CONFIG='{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
-          find . -path ./node_modules -prune -o \(
-            -name '*.yaml' -o -name '*.yml' \) -print0 |
-            xargs -0 yamllint -d "$CONFIG"
+          find . -path ./node_modules -prune -o \( \
+            -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "$CONFIG"
 
       - name: Check for TODO, Coming soon, or placeholder
         run: |


### PR DESCRIPTION
## Summary
- fix YAML validation command to avoid line length issues in workflow

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` *(with custom config)*
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh` *(fails: WARN cached status 0)*
- `grep -oP '^prompt_version' config/settings.yaml`

------
https://chatgpt.com/codex/tasks/task_b_6844fce3cb7c833389bc2fa3a701949c