### PR TITLE
feat: implement governance heartbeat tracking

### DIFF
--- a/src/agents/governance_agent.py
+++ b/src/agents/governance_agent.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import time
+from typing import Dict
+
 from ..core.base_agent import BaseAgent
 
 class GovernanceAgent(BaseAgent):
@@ -5,9 +10,18 @@ class GovernanceAgent(BaseAgent):
 
     def __init__(self) -> None:
         super().__init__(name="GovernanceAgent")
+        self._heartbeats: Dict[str, float] = {}
+
+    def record_heartbeat(self, agent_name: str) -> None:
+        """Record a heartbeat timestamp for another agent."""
+        self._heartbeats[agent_name] = time.time()
 
     def run(self, status: str) -> str:
-        # Placeholder heartbeat check
+        now = time.time()
+        stale = [name for name, ts in self._heartbeats.items() if now - ts > 30]
+        if stale:
+            agents = ", ".join(stale)
+            return f"{self.name} ALERT: {agents} heartbeat stale"
         return f"{self.name} reviewed status: {status}"
 
 if __name__ == "__main__":

--- a/tests/test_agents_extra.py
+++ b/tests/test_agents_extra.py
@@ -2,6 +2,7 @@ import unittest
 from src.agents.content_agent import ContentAgent
 from src.agents.analytics_agent import AnalyticsAgent
 from src.agents.ab_testing_agent import AbTestingAgent
+from src.agents.governance_agent import GovernanceAgent
 
 
 class TestExtraAgents(unittest.TestCase):
@@ -24,6 +25,21 @@ class TestExtraAgents(unittest.TestCase):
         }
         result = agent.run(variants)
         self.assertIn('B', result)
+
+    def test_governance_agent_detects_stale_heartbeat(self):
+        agent = GovernanceAgent()
+        agent.record_heartbeat('AnalyticsAgent')
+        # Simulate stale heartbeat
+        agent._heartbeats['AnalyticsAgent'] -= 31
+        result = agent.run('ok')
+        self.assertIn('ALERT', result)
+        self.assertIn('AnalyticsAgent', result)
+
+    def test_governance_agent_no_alert_for_recent_heartbeat(self):
+        agent = GovernanceAgent()
+        agent.record_heartbeat('ContentAgent')
+        result = agent.run('ok')
+        self.assertNotIn('ALERT', result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- track heartbeats in GovernanceAgent
- alert on stale heartbeats over 30 seconds
- test heartbeat detection behaviour

## Testing
- `npm ci --omit=optional` *(fails: 403 Forbidden)*
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684500ae9ccc83339f5cbaf01c7f5060