### PR TITLE
Add TikTok Ads API docs

### DIFF
--- a/docs/integration_guide_o3.md
+++ b/docs/integration_guide_o3.md
@@ -24,6 +24,7 @@ Use GitHub repository: https://github.com/DanCanadian/ADK
   - `neurogym_neuromarketing.md`
   - `meta_ai_strategy.md`
   - `google_insights_summary.md`
+  - `integrations/tiktok_ads_api.md`
   - `ibm_ai_learning.md`
   - `gemini_api_docs.md`
   - `openai_api_docs.md`

--- a/docs/integrations/tiktok_ads_api.md
+++ b/docs/integrations/tiktok_ads_api.md
@@ -1,0 +1,29 @@
+# TikTok Ads API Integration
+
+**URL:** https://ads.tiktok.com/marketing_api/
+**Relevance:** campaign creation, analytics
+**Used by Agents:** MarketingAgent, ReportingAgent
+
+## Token Acquisition
+1. Apply for a TikTok for Business developer account and create an app.
+2. Record the generated **App ID** and **App Secret** from the developer portal.
+3. Request advertiser authorization to access account data.
+4. Exchange the authorization code for an access token using the `/oauth2/access_token/` endpoint.
+5. Store and refresh the token securely with `/oauth2/refresh_token/` when needed.
+
+## Example API Calls
+
+```bash
+# List advertisers connected to your app
+curl -G "https://business-api.tiktok.com/open_api/v1.3/oauth2/advertiser/get/" \
+  -d "access_token=$ACCESS_TOKEN"
+
+# Retrieve campaigns for an advertiser
+curl -X POST "https://business-api.tiktok.com/open_api/v1.3/campaign/get/" \
+  -H "Access-Token: $ACCESS_TOKEN" \
+  -d '{"advertiser_id":"$ADVERTISER_ID"}'
+```
+
+## Security Guidance
+- Do not embed tokens in code repositories.
+- Use environment variables or a secrets manager for runtime access.

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -359,6 +359,18 @@
       "version": "1.0.0"
     },
     {
+      "name": "TikTok Ads API Integration",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/integrations/tiktok_ads_api.md",
+      "tags": [
+        "tiktok",
+        "ads-api",
+        "marketing",
+        "analytics"
+      ],
+      "version": "1.0.0",
+      "type": "integration"
+    },
+    {
       "name": "O3 Release Checklist",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/meta/release_checklist_v3.5.md",
       "tags": [

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -33,6 +33,10 @@ ADK/
         ├── mckinsey_ai_marketing.md
         ├── neurogym_neuromarketing.md
         └── reforge_growth_loops.md
+    ├── integrations/
+        ├── google_ads_api.md
+        ├── meta_ads_api.md
+        └── tiktok_ads_api.md
     ├── config_agent_overview.md
     ├── world_agent_integration.md
 ```


### PR DESCRIPTION
## Summary
- document TikTok Ads API with token acquisition steps and sample requests
- include new integration in the docs tree and source index
- cross-link TikTok Ads API from integration guide

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on repo YAML files
- `grep` for TODOs
- `bash` checks for required files
- version consistency check
- golden prompt validation
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- manual file existence checks
- prompt genome and version validations

------
https://chatgpt.com/codex/tasks/task_b_684515e36fb88333914664e65a8a5518