### PR TITLE
Add CLV and retention metrics

### DIFF
--- a/docs/analytics/metrics_pipeline.md
+++ b/docs/analytics/metrics_pipeline.md
@@ -16,3 +16,31 @@ This page outlines how raw campaign metrics are turned into KPIs.
 - **ROAS (Return on Ad Spend)** = Revenue / Cost
 
 The `MetricsCollector.collect()` method aggregates raw values and computes these KPIs for use by analytics agents.
+
+## Advanced KPIs
+
+### Customer Lifetime Value (CLV)
+CLV measures the revenue generated per customer over their lifetime.
+`CLV = Total Revenue / Total Conversions`
+
+### Cost per Acquisition (CPA)
+CPA measures the average cost to acquire a customer.
+`CPA = Total Cost / Total Conversions`
+
+### Retention Metrics
+Retention shows how many customers return after the initial conversion.
+Typical formulas include:
+- **Retention Rate** = Returning Customers / Total Conversions
+- **Churn Rate** = 1 - Retention Rate
+
+```python
+collector.add(
+    impressions=100,
+    clicks=10,
+    cost=5.0,
+    conversions=2,
+    revenue=20.0,
+    returning_customers=1,
+)
+kpis = collector.collect()
+```

--- a/docs/reporting_dashboard.md
+++ b/docs/reporting_dashboard.md
@@ -7,3 +7,4 @@ The reporting dashboard centralizes campaign metrics for quick review.
 - Generate shareable reports for stakeholders
 - Export metrics to JSON
 - Export metrics to CSV for deeper analysis
+- Track KPIs such as CTR, CPC, ROAS, CLV, CPA and retention rate

--- a/examples/ads_integration_workflow.py
+++ b/examples/ads_integration_workflow.py
@@ -5,7 +5,14 @@ from src.core.reporting import ReportGenerator
 
 def main() -> None:
     collector = MetricsCollector()
-    collector.add(impressions=1200, clicks=160, cost=80.0, conversions=20, revenue=320.0)
+    collector.add(
+        impressions=1200,
+        clicks=160,
+        cost=80.0,
+        conversions=20,
+        revenue=320.0,
+        returning_customers=8,
+    )
     metrics = collector.collect()
 
     reporter = ReportGenerator()

--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -4,7 +4,15 @@ class MetricsCollector:
     def __init__(self) -> None:
         self.records = []
 
-    def add(self, impressions: int, clicks: int, cost: float, conversions: int, revenue: float) -> None:
+    def add(
+        self,
+        impressions: int,
+        clicks: int,
+        cost: float,
+        conversions: int,
+        revenue: float,
+        returning_customers: int = 0,
+    ) -> None:
         """Add a new set of raw metrics."""
         self.records.append({
             "impressions": impressions,
@@ -12,6 +20,7 @@ class MetricsCollector:
             "cost": cost,
             "conversions": conversions,
             "revenue": revenue,
+            "returning_customers": returning_customers,
         })
 
     def collect(self) -> dict:
@@ -21,11 +30,15 @@ class MetricsCollector:
         total_cost = sum(r["cost"] for r in self.records)
         total_conversions = sum(r["conversions"] for r in self.records)
         total_revenue = sum(r["revenue"] for r in self.records)
+        total_returning = sum(r.get("returning_customers", 0) for r in self.records)
 
         ctr = (total_clicks / total_impressions) if total_impressions else 0.0
         cpc = (total_cost / total_clicks) if total_clicks else 0.0
         conversion_rate = (total_conversions / total_clicks) if total_clicks else 0.0
         roas = (total_revenue / total_cost) if total_cost else 0.0
+        clv = (total_revenue / total_conversions) if total_conversions else 0.0
+        cpa = (total_cost / total_conversions) if total_conversions else 0.0
+        retention_rate = (total_returning / total_conversions) if total_conversions else 0.0
 
         return {
             "impressions": total_impressions,
@@ -37,4 +50,7 @@ class MetricsCollector:
             "CPC": cpc,
             "ConversionRate": conversion_rate,
             "ROAS": roas,
+            "CLV": clv,
+            "CPA": cpa,
+            "RetentionRate": retention_rate,
         }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,7 +68,14 @@ class TestEventBus(unittest.TestCase):
 class TestMetricsCollector(unittest.TestCase):
     def test_collect_kpis(self):
         mc = MetricsCollector()
-        mc.add(impressions=1000, clicks=100, cost=50.0, conversions=10, revenue=200.0)
+        mc.add(
+            impressions=1000,
+            clicks=100,
+            cost=50.0,
+            conversions=10,
+            revenue=200.0,
+            returning_customers=5,
+        )
         result = mc.collect()
         self.assertEqual(result['impressions'], 1000)
         self.assertEqual(result['clicks'], 100)
@@ -76,15 +83,28 @@ class TestMetricsCollector(unittest.TestCase):
         self.assertAlmostEqual(result['CPC'], 0.5)
         self.assertAlmostEqual(result['ConversionRate'], 0.1)
         self.assertAlmostEqual(result['ROAS'], 4.0)
+        self.assertAlmostEqual(result['CLV'], 20.0)
+        self.assertAlmostEqual(result['CPA'], 5.0)
+        self.assertAlmostEqual(result['RetentionRate'], 0.5)
 
     def test_zero_division(self):
         mc = MetricsCollector()
-        mc.add(impressions=0, clicks=0, cost=0.0, conversions=0, revenue=0.0)
+        mc.add(
+            impressions=0,
+            clicks=0,
+            cost=0.0,
+            conversions=0,
+            revenue=0.0,
+            returning_customers=0,
+        )
         result = mc.collect()
         self.assertEqual(result['CTR'], 0.0)
         self.assertEqual(result['CPC'], 0.0)
         self.assertEqual(result['ConversionRate'], 0.0)
         self.assertEqual(result['ROAS'], 0.0)
+        self.assertEqual(result['CLV'], 0.0)
+        self.assertEqual(result['CPA'], 0.0)
+        self.assertEqual(result['RetentionRate'], 0.0)
 
 
 class TestQueueLimits(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expand KPI docs with CLV, CPA and retention metrics
- extend `MetricsCollector` with new KPI calculations
- adjust tests and example workflow for new fields
- reference new metrics in the reporting dashboard

## Testing
- `pytest -q`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }' $(find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print)`


------
https://chatgpt.com/codex/tasks/task_b_684517352de483338cc430de5e716ca5