### PR TITLE
Add marketing workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ Key references:
 - docs/meta/prompt_genome.json  # Version and lineage tracking
 - docs/source_index.json
 
-Run the demo workflow:
+Run the demo workflows:
 
 ```bash
 python examples/simple_workflow.py
+python examples/marketing_workflow.py
 ```
 
 ## 🛠️ CI/CD Validation

--- a/examples/marketing_workflow.py
+++ b/examples/marketing_workflow.py
@@ -1,0 +1,51 @@
+"""Demonstrate agents collaborating via AsyncEventBus."""
+import asyncio
+
+from src.core import AsyncEventBus, get_logger
+from src.agents.campaign_agent import CampaignAgent
+from src.agents.engagement_agent import EngagementAgent
+from src.agents.analytics_agent import AnalyticsAgent
+
+
+event_bus = AsyncEventBus()
+logger = get_logger("MarketingWorkflow")
+
+campaign_agent = CampaignAgent()
+engagement_agent = EngagementAgent()
+analytics_agent = AnalyticsAgent()
+
+
+async def handle_campaign(product: str) -> None:
+    """Plan a campaign then trigger engagement."""
+    # Advantage+ approach for dynamic creative optimization
+    # docs/performance_marketing/meta_ai_strategy.md lines 8-11
+    logger.info(campaign_agent.run(product))
+    await event_bus.publish("engage", f"prospect interested in {product}")
+
+
+async def handle_engage(prospect: str) -> None:
+    """Nurture the lead and forward metrics."""
+    # Smart Bidding concepts apply to lead targeting
+    # docs/performance_marketing/google_insights_summary.md lines 8-11
+    logger.info(engagement_agent.run(prospect))
+    await event_bus.publish("report", f"conversion data for {prospect}")
+
+
+async def handle_report(data: str) -> None:
+    """Analyze campaign performance."""
+    # Growth loops emphasize rapid test→analyze→deploy cycles
+    # docs/performance_marketing/reforge_growth_loops.md lines 9-19
+    logger.info(analytics_agent.run(data))
+
+
+event_bus.subscribe("launch", handle_campaign)
+event_bus.subscribe("engage", handle_engage)
+event_bus.subscribe("report", handle_report)
+
+
+async def main() -> None:
+    await event_bus.publish("launch", "new SaaS product")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `marketing_workflow.py` example showing async agent collaboration
- link the new example in the README quick start

## Testing
- `python -m pytest -q`
- `npx markdownlint-cli2 "docs/**/*.md" \!docs/legacy/**`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' $(find . -path ./node_modules -prune -o -name '*.yml' -o -name '*.yaml' -print)`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_684517ff43f483338d7834fc1b3235b3