### PR TITLE
fix: yamllint warnings

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -1,7 +1,7 @@
 ---
 name: CI Validate O3 Repo v3.5.7
 
-on:
+'on':
   pull_request:
   push:
     branches:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli2
     rev: v0.7.0

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,3 +1,4 @@
+---
 # Default configuration for ADK agents
 prompt_version: 3.5.7  # prompt kernel version
 routing_weight: 1      # weight for ConfigAgent routing


### PR DESCRIPTION
## Summary
- add YAML separators to repo config files
- quote workflow trigger to avoid YAML warnings

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `CONFIG='{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
  find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "$CONFIG"

------
https://chatgpt.com/codex/tasks/task_b_684521973c808333b48622bd012e3f83