### PR TITLE
Fix offline link regex

### DIFF
--- a/scripts/offline_link_check.sh
+++ b/scripts/offline_link_check.sh
@@ -7,7 +7,7 @@ if [ ! -f "$CACHE_FILE" ]; then
   echo "Cache file $CACHE_FILE not found" >&2
   exit 1
 fi
-links=$(grep -rhoP 'https?://[^ )]+' docs/external | sort -u)
+links=$(grep -rhoP "https?://[^ )\"\\',]+" docs/external | sort -u)
 for link in $links; do
   status=$(grep -F "$link" "$CACHE_FILE" | head -n 1 | awk '{print $2}')
   if [ -z "$status" ]; then


### PR DESCRIPTION
## Summary
- trim trailing punctuation when extracting links for offline check

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' $(find . -path ./node_modules -prune -o -name '*.yaml' -o -name '*.yml' -print)`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/offline_link_check.sh > /tmp/offline.log 2>&1; tail -n 5 /tmp/offline.log`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68452594b57883339c0a0d05ebf24742