### PR TITLE
chore: refresh link cache

### DIFF
--- a/docs/link_cache.txt
+++ b/docs/link_cache.txt
@@ -2,9 +2,9 @@ https://aif360.readthedocs.io/ 0
 https://airtable.com/developers/web/api/introduction 0
 https://api.amplitude.com/2/httpapi 0
 https://arxiv.org/abs/2202.11382 0
-https://cloud.google.com/vertex-ai/docs/generative-ai/grounding 0
+https://cloud.google.com/vertex-ai/docs/generative-ai/grounding 404
 https://developer.apple.com/machine-learning/ 0
-https://developers.google.com/docs 0
+https://developers.google.com/docs 200
 https://docs.anthropic.com 0
 https://docs.anthropic.com/claude/prompting-best-practices 0
 https://docs.langchain.com 0
@@ -13,10 +13,10 @@ https://docs.ray.io/en/latest/serve/ 0
 https://docs.wandb.ai/ 0
 https://fastapi.tiangolo.com/ 0
 https://gdpr.eu 0
-https://github.com/AutogenStudio/autogen 0
-https://github.com/google-research/FLAN 0
-https://github.com/openai/openai-cookbook 0
-https://github.com/thunlp/OpenPrompt 0
+https://github.com/AutogenStudio/autogen 404
+https://github.com/google-research/FLAN 200
+https://github.com/openai/openai-cookbook 200
+https://github.com/thunlp/OpenPrompt 200
 https://helm.sh/docs/ 0
 https://mcp-docs.readthedocs.io/ 0
 https://mlflow.org/docs/latest/index.html 0


### PR DESCRIPTION
## Summary
- refresh external link status cache

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on project YAML files
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- `test -f docs/performance_marketing/reforge_growth_loops.md`
- `test -f docs/legacy/prompt/prompt_kernel_v3.4.md`
- `test -f docs/meta/prompt_genome.json`
- `version=$(jq -r '.versions[] | select(.tag=="v3.4")' docs/meta/prompt_genome.json)`
- `grep -oP '^prompt_version:\s*\K[0-9]+\.[0-9]+\.[0-9]+' config/settings.yaml`


------
https://chatgpt.com/codex/tasks/task_b_68454bde21b483339968093eba02f54c