### PR TITLE
Add pre-commit to CI workflow

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -180,5 +180,11 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
       - name: Run unit tests
         run: python -m unittest discover tests


### PR DESCRIPTION
## Summary
- install pre-commit in the validation workflow
- run `pre-commit` across all files during CI

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }"`
- `bash scripts/offline_link_check.sh`
- `python -m unittest discover tests`
- `pre-commit run --all-files` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_b_6845542dc4f88333a931c8f562459e6f