### PR TITLE
Add pip cache to CI

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -177,6 +177,14 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 


### PR DESCRIPTION
## Summary
- cache `~/.cache/pip` in `validate_repo.yml`
- reuse cache before installing Python dependencies

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json > /dev/null && jq . docs/meta/prompt_genome.json > /dev/null && jq . docs/meta/meta_evaluation.json > /dev/null`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- `python -m unittest discover tests`
- `pre-commit run --all-files` *(fails: Username for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_b_684555287ff483339456d03c5f21c487