### PR TITLE
chore: validate evaluation results version

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -172,6 +172,18 @@ jobs:
             echo "✅ prompt_version $SETTINGS_VERSION matches VERSION"
           fi
 
+      - name: Verify evaluation_results version matches VERSION
+        run: |
+          echo "Checking evaluation_results.json version..."
+          JSON_VERSION=$(jq -r '.version' docs/meta/evaluation_results.json)
+          FILE_VERSION=$(tr -d '[:space:]' < VERSION)
+          if [ "$JSON_VERSION" != "$FILE_VERSION" ]; then
+            echo "❌ evaluation_results.json version ($JSON_VERSION) does not match VERSION ($FILE_VERSION)"
+            exit 1
+          else
+            echo "✅ evaluation_results.json version matches VERSION"
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Summary
- ensure `evaluation_results.json` uses same version as the `VERSION` file

## Testing
- `npm ci --omit=optional`
- `pip install -r requirements.txt`
- `pip install pre-commit`
- `pre-commit run --all-files` *(fails: prompts for GitHub credentials)*
- `python -m unittest discover tests`
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`


------
https://chatgpt.com/codex/tasks/task_b_6845562464dc83338de6ff36b9750243