### PR TITLE
Add evaluation generation script

### DIFF
--- a/docs/meta/evaluation_results.json
+++ b/docs/meta/evaluation_results.json
@@ -7,5 +7,6 @@
     "efficiency": 5
   },
   "reviewer": "QA Team",
-  "date": "2025-06-02"
+  "date": "2025-06-08",
+  "score": 4.75
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,13 @@ Both scripts exit non‑zero on failure so they can be used in automation.
   python scripts/refresh_link_cache.py
   ```
 
+* `generate_evaluation.py` – Computes a weighted evaluation score from a metrics
+  file and updates `docs/meta/evaluation_results.json`:
+
+  ```bash
+  python scripts/generate_evaluation.py metrics.json
+  ```
+
 * `bump_version.sh` – Bumps all documentation references to a new version and writes
   the string to the `VERSION` file. If `CHANGELOG.md` contains an `Unreleased`
   section, it is replaced with the new version and today's date.

--- a/scripts/generate_evaluation.py
+++ b/scripts/generate_evaluation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Generate evaluation score and update results file."""
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+    YAML_AVAILABLE = True
+except Exception:
+    YAML_AVAILABLE = False
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.core.evaluation import evaluate
+
+
+def load_metrics(path: Path) -> dict:
+    """Load metrics from a JSON or YAML file."""
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in {".yaml", ".yml"}:
+        if not YAML_AVAILABLE:
+            raise RuntimeError("PyYAML is required for YAML input")
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate evaluation results")
+    parser.add_argument("metrics_file", help="Path to metrics JSON or YAML file")
+    args = parser.parse_args()
+
+    metrics_path = Path(args.metrics_file)
+    metrics = load_metrics(metrics_path)
+
+    score = evaluate(metrics)
+
+    results_path = Path("docs") / "meta" / "evaluation_results.json"
+    results = {}
+    if results_path.exists():
+        results = json.loads(results_path.read_text(encoding="utf-8"))
+
+    version = Path("VERSION").read_text(encoding="utf-8").strip()
+    results.update({
+        "version": version,
+        "scores": metrics,
+        "score": score,
+        "date": date.today().isoformat(),
+    })
+    results.setdefault("reviewer", "Automated")
+
+    results_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote evaluation results to {results_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_evaluation.py` script to compute weighted evaluation scores
- document the new helper in the scripts README
- refresh evaluation results with calculated score

## Testing
- `python -m unittest discover tests`
- `pre-commit run --all-files` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_b_6845574de4008333a266ce3ae8366345