### PR TITLE
ci: add commit prefix validation

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Validate commit message prefix
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          echo "Latest commit message: $COMMIT_MSG"
+          if ! echo "$COMMIT_MSG" | grep -Eq '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert):'; then
+            echo "❌ Commit message must start with an approved prefix"
+            exit 1
+          fi
+          echo "✅ Commit message prefix check passed"
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -170,7 +180,8 @@ jobs:
             exit 1
           fi
 
-          ACTIVE_COUNT=$(jq -r '.prompt_genome.prompts[] | select(.status=="active") | .id' docs/meta/prompt_genome.json | grep -c "v$FILE_VERSION" || true)
+          ACTIVE_COUNT=$(jq -r '.prompt_genome.prompts[] | select(.status=="active") | .id' \
+            docs/meta/prompt_genome.json | grep -c "v$FILE_VERSION" || true)
           if [ "$ACTIVE_COUNT" -eq 0 ]; then
             echo "❌ No active prompt genome entry matches VERSION $FILE_VERSION"
             exit 1
@@ -182,7 +193,8 @@ jobs:
             exit 1
           fi
 
-          README_VERSION=$(grep -oP 'Golden Prompts \(v\K[0-9]+\.[0-9]+\.[0-9]+' tests/golden_prompts/README.md | head -1)
+          README_VERSION=$(grep -oP 'Golden Prompts \(v\K[0-9]+\.[0-9]+\.[0-9]+' \
+            tests/golden_prompts/README.md | head -1)
           if [ "$README_VERSION" != "$FILE_VERSION" ]; then
             echo "❌ Golden Prompts README version ($README_VERSION) does not match VERSION ($FILE_VERSION)"
             exit 1


### PR DESCRIPTION
## Summary
- ensure commit messages have an approved prefix
- fix long YAML lines to satisfy yamllint

## Testing
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }"`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh`
- `python -m unittest discover tests`
- `pip install -r requirements.txt`
- `pip install pre-commit` *(fails: GitHub authentication required)*


------
https://chatgpt.com/codex/tasks/task_b_684559381dac8333afb49199be2497ce