### PR TITLE
Fix tag_release workflow formatting

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,6 +1,7 @@
+---
 name: Tag Release
 
-on:
+'on':
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
- add missing YAML header for tag release workflow
- quote the `on` key

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}'`
- `bash scripts/validate_golden_prompts.sh`
- `python -m unittest discover tests`
- `yamllint -d '{extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}}}' .github/workflows/tag_release.yml`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68465591a70483338992fbee7d4b38cd