### PR TITLE
fix: verify sudo in setup script

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 # Install Node.js and tools locally only if missing
 SUDO=""
 if [ "$(id -u)" -ne 0 ]; then
-  SUDO="sudo"
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    echo "This script requires root privileges (sudo missing)." >&2
+    exit 1
+  fi
 fi
 
 packages=()


### PR DESCRIPTION
# 🚀 Pull Request Summary - v3.5.7

## 📋 Description of Changes
- verify that `sudo` exists before using it in `scripts/setup_env.sh`

---

## 🗂 Affected Files (v3.5.7)

### Core Files
- [ ] `docs/prompt/prompt_kernel_v3.5.md`
- [ ] `docs/meta/prompt_evolution_log/v3.5.yaml`
- [ ] `docs/meta/meta_evaluation.json`

### Test Files
- [ ] `tests/golden_prompts/test_prompt_coordinator.md`
- [ ] `tests/golden_prompts/test_memory_reflection.md`
- [ ] `tests/golden_prompts/test_kpi_optimization.md`

### Supporting Files
- [ ] `docs/source_index.json`
- [ ] `CHANGELOG.md`
- [ ] `README.md`

### CI/CD
- [ ] `.github/workflows/validate_repo.yml`
- [ ] `.github/pull_request_template.md`

---

## 🧪 Golden Prompt Integration
- [ ] Added test_prompt_coordinator.md to `/tests/golden_prompts/`
- [ ] Added test_memory_reflection.md to `/tests/golden_prompts/`
- [ ] Added test_kpi_optimization.md to `/tests/golden_prompts/`
- [ ] CI configured to detect and validate golden prompts
- [ ] Golden prompts align with v3.5.7 kernel strategy

---

## ✅ Validation Checklist
- [x] No `TODO:`, `Coming soon`, or `placeholder` remaining
- [ ] Links (internal/external) validated
- [ ] `source_index.json` updated if new `.md` was added
- [ ] `CHANGELOG.md` updated with version bump
- [x] PR title follows format: `feat:` `fix:` `chore:` etc.
- [x] Golden prompts pass validation checks
- [ ] All tests are passing

---

## 🧠 Notes & Context (optional)
Pre-commit hooks requiring remote repository access could not be installed due to environment restrictions. Offline link check reported missing cache statuses, leading to a non-zero exit code.


------
https://chatgpt.com/codex/tasks/task_b_6846584b16d08333b0d627db0a917ebe