### PR TITLE
Centralize golden prompt validation

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -120,36 +120,7 @@ jobs:
           fi
 
       - name: Validate Golden Prompts
-        run: |
-          echo "Validating golden prompts..."
-          for file in tests/golden_prompts/*.md; do
-            if [[ $(basename "$file") == "README.md" ]]; then
-              continue
-            fi
-            echo "🔍 Validating $file"
-
-            # Check required sections
-            for section in "INPUT" "EXPECTED" "NOTES"; do
-              if ! grep -q "^### $section" "$file"; then
-                echo "❌ Missing section: $section in $file"
-                exit 1
-              fi
-            done
-
-            # Check for required tags
-            if ! grep -q "^\*\*Tags:\*\*" "$file"; then
-              echo "❌ Missing or incorrectly formatted Tags in $file. Expected format: **Tags:** value1, value2"
-              exit 1
-            fi
-
-            # Check for version compatibility
-            if ! grep -q "v3\.5" "$file"; then
-              echo "❌ Version not specified or incorrect in $file"
-              exit 1
-            fi
-
-            echo "✅ $file is valid"
-          done
+        run: bash scripts/validate_golden_prompts.sh
 
 
       - name: Refresh Link Cache

--- a/scripts/validate_golden_prompts.sh
+++ b/scripts/validate_golden_prompts.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Read the major/minor version prefix from the VERSION file
+VERSION_PREFIX=$(cut -d. -f1-2 VERSION)
+
 echo "Validating golden prompts..."
 for file in tests/golden_prompts/*.md; do
   if [ "$(basename "$file")" = "README.md" ]; then
@@ -17,8 +20,8 @@ for file in tests/golden_prompts/*.md; do
     echo "Missing Tags in $file" >&2
     exit 1
   fi
-  if ! grep -q 'v3\.5' "$file"; then
-    echo "Version not specified in $file" >&2
+  if ! grep -q "v${VERSION_PREFIX}" "$file"; then
+    echo "Version not specified or incorrect in $file" >&2
     exit 1
   fi
   echo "$file is valid"


### PR DESCRIPTION
## Summary
- read version prefix from `VERSION` in validation script
- reuse validation script in workflow

## Testing
- `bash scripts/validate_golden_prompts.sh`
- `python -m unittest discover tests`
- `pre-commit run --files scripts/validate_golden_prompts.sh .github/workflows/validate_repo.yml` *(fails: requires GitHub access)*

------
https://chatgpt.com/codex/tasks/task_b_684659d1638883339be351cc74b2a0ab