### PR TITLE
Fix setup_env curl check

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 Two helper scripts streamline validation and development:
 
-* `setup_env.sh` – Installs Node.js, markdownlint, `jq`, and `yamllint` so local
+* `setup_env.sh` – Installs Node.js, curl, markdownlint, `jq`, and `yamllint` so local
   checks match CI. Run once after cloning:
 
   ```bash

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -14,6 +14,10 @@ fi
 
 packages=()
 
+if ! command -v curl >/dev/null; then
+  packages+=(curl)
+fi
+
 # Node.js 18 is required
 need_node=false
 if command -v node >/dev/null && command -v npm >/dev/null; then


### PR DESCRIPTION
## Summary
- update `setup_env.sh` to add curl when missing
- document curl dependency in scripts README

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }"`
- `bash scripts/validate_golden_prompts.sh`

------
https://chatgpt.com/codex/tasks/task_b_68465f01576883338c4c12bdf6f48e10