### PR TITLE
docs: clarify merge commit requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ Ensure the following items are checked before requesting review:
 - [ ] `source_index.json` updated if new `.md` was added
 - [ ] `CHANGELOG.md` updated with version bump
 - [ ] PR title follows format: `feat:` `fix:` `chore:` etc.
-- [ ] Merge commits reworded or squashed to include a prefix
+- [ ] Merge commits reworded (e.g., `chore: merge master into feature-X`) or squashed
 - [ ] Golden prompts pass validation checks
 - [ ] All tests are passing
 

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -41,3 +41,7 @@ git commit --amend -m "chore: merge master into feature-X"
 ```
 
 This ensures CI passes for merge commits.
+
+**Note:** Merge commits with messages like `Merge branch 'master'` must be
+reworded (e.g., `chore: merge master into feature-X`) or squashed before
+pushing. Otherwise CI will block the PR.


### PR DESCRIPTION
## Summary
- advise contributors to reword merge commits or squash them
- show example in PR template checklist

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on repo YAML files
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include='*.md' --include='*.yaml' --include='*.yml' --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_b_684661727d848333a24b5b2db5b17a99