### PR TITLE
Fix commit prefix guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ pre-commit install
 ```
 
 Running `pre-commit` will execute markdownlint, yamllint, golden prompt validation, and unit tests.
+All commit messages must start with an approved prefix (for example `feat:` or `fix:`). See [docs/contribution_guide.md](docs/contribution_guide.md#commit-messages) for details.
 
 ### Running Tests Manually
 You can execute the full test suite without the pre-commit hooks:


### PR DESCRIPTION
## Summary
- mention commit prefix requirement in README

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on all YAML files
- `bash scripts/validate_golden_prompts.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684665d5308c8333b8381bb2f94cbfe3