### PR TITLE
Add Python linting and formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -199,6 +199,12 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
 
+      - name: Run flake8
+        run: flake8
+
+      - name: Run black check
+        run: black --check .
+
       - name: Install pre-commit
         run: pip install pre-commit
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,15 @@
 ---
 repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+        language_version: python3
   - repo: https://github.com/igorshubovych/markdownlint-cli2
     rev: v0.7.0
     hooks:

--- a/examples/ads_integration_workflow.py
+++ b/examples/ads_integration_workflow.py
@@ -1,4 +1,5 @@
 """Example workflow integrating MetricsCollector and ReportGenerator."""
+
 from o3research.core.metrics import MetricsCollector
 from o3research.core.reporting import ReportGenerator
 

--- a/examples/marketing_workflow.py
+++ b/examples/marketing_workflow.py
@@ -1,4 +1,5 @@
 """Demonstrate agents collaborating via AsyncEventBus."""
+
 import asyncio
 
 from o3research.core import AsyncEventBus, get_logger

--- a/examples/simple_workflow.py
+++ b/examples/simple_workflow.py
@@ -1,4 +1,5 @@
 """Run a basic workflow using AsyncEventBus and sample agents."""
+
 import asyncio
 from o3research.mcp_server import MCPServer
 from o3research.core import AsyncEventBus, get_logger
@@ -13,6 +14,7 @@ async def handle_research(msg: str) -> None:
     logger.info(server.route("research", msg))
     await asyncio.sleep(0.1)
     logger.info(server.route("content", msg))
+
 
 async def handle_optimize(msg: str) -> None:
     logger.info(server.route("optimize", msg))

--- a/o3research/agents/governance_agent.py
+++ b/o3research/agents/governance_agent.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 from ..core.base_agent import BaseAgent
 
+
 class GovernanceAgent(BaseAgent):
     """Prototype agent to monitor other agents and handle escalation."""
 
@@ -23,6 +24,7 @@ class GovernanceAgent(BaseAgent):
             agents = ", ".join(stale)
             return f"{self.name} ALERT: {agents} heartbeat stale"
         return f"{self.name} reviewed status: {status}"
+
 
 if __name__ == "__main__":
     agent = GovernanceAgent()

--- a/o3research/core/__init__.py
+++ b/o3research/core/__init__.py
@@ -2,3 +2,5 @@ from .event_bus import EventBus
 from .async_event_bus import AsyncEventBus
 from .logger import get_logger
 from .reporting import ReportGenerator
+
+__all__ = ["EventBus", "AsyncEventBus", "get_logger", "ReportGenerator"]

--- a/o3research/core/async_event_bus.py
+++ b/o3research/core/async_event_bus.py
@@ -2,6 +2,7 @@ import asyncio
 from collections import defaultdict
 from .types import AsyncCallback
 
+
 class AsyncEventBus:
     """Simple asyncio-based publish/subscribe bus."""
 

--- a/o3research/core/evaluation.py
+++ b/o3research/core/evaluation.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 def _load_meta_evaluation() -> dict:
     """Load evaluation metadata from JSON."""
-    path = Path(__file__).resolve().parents[2] / "docs" / "meta" / "meta_evaluation.json"
+    path = (
+        Path(__file__).resolve().parents[2] / "docs" / "meta" / "meta_evaluation.json"
+    )
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -25,7 +27,10 @@ def evaluate(metrics: dict[str, float]) -> float:
     float
         Weighted evaluation score. Returns 0.0 if no weights match.
     """
-    weights = {m["id"]: m.get("weight", 0.0) for m in META_EVALUATION.get("evaluation_metrics", [])}
+    weights = {
+        m["id"]: m.get("weight", 0.0)
+        for m in META_EVALUATION.get("evaluation_metrics", [])
+    }
     weighted_sum = 0.0
     total_weight = 0.0
     for name, score in metrics.items():

--- a/o3research/core/logger.py
+++ b/o3research/core/logger.py
@@ -6,7 +6,7 @@ def get_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     if not logger.handlers:
         handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(handler)
         logger.setLevel(logging.INFO)

--- a/o3research/core/metrics.py
+++ b/o3research/core/metrics.py
@@ -14,14 +14,16 @@ class MetricsCollector:
         returning_customers: int = 0,
     ) -> None:
         """Add a new set of raw metrics."""
-        self.records.append({
-            "impressions": impressions,
-            "clicks": clicks,
-            "cost": cost,
-            "conversions": conversions,
-            "revenue": revenue,
-            "returning_customers": returning_customers,
-        })
+        self.records.append(
+            {
+                "impressions": impressions,
+                "clicks": clicks,
+                "cost": cost,
+                "conversions": conversions,
+                "revenue": revenue,
+                "returning_customers": returning_customers,
+            }
+        )
 
     def collect(self) -> dict:
         """Return aggregated metrics along with computed KPIs."""
@@ -38,7 +40,9 @@ class MetricsCollector:
         roas = (total_revenue / total_cost) if total_cost else 0.0
         clv = (total_revenue / total_conversions) if total_conversions else 0.0
         cpa = (total_cost / total_conversions) if total_conversions else 0.0
-        retention_rate = (total_returning / total_conversions) if total_conversions else 0.0
+        retention_rate = (
+            (total_returning / total_conversions) if total_conversions else 0.0
+        )
 
         return {
             "impressions": total_impressions,

--- a/o3research/mcp_server.py
+++ b/o3research/mcp_server.py
@@ -1,4 +1,5 @@
 """Minimal orchestrator that routes tasks to sample agents."""
+
 from .agents.research_agent import ResearchAgent
 from .agents.content_agent import ContentAgent
 from .agents.engagement_agent import EngagementAgent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ version = {file = "VERSION"}
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 PyYAML>=6.0
+black
+flake8

--- a/scripts/generate_evaluation.py
+++ b/scripts/generate_evaluation.py
@@ -6,16 +6,17 @@ import sys
 from datetime import date
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 try:
     import yaml  # type: ignore
+
     YAML_AVAILABLE = True
 except Exception:
     YAML_AVAILABLE = False
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
-
-from o3research.core.evaluation import evaluate
+from o3research.core.evaluation import evaluate  # noqa: E402
 
 
 def load_metrics(path: Path) -> dict:
@@ -44,12 +45,14 @@ def main() -> None:
         results = json.loads(results_path.read_text(encoding="utf-8"))
 
     version = Path("VERSION").read_text(encoding="utf-8").strip()
-    results.update({
-        "version": version,
-        "scores": metrics,
-        "score": score,
-        "date": date.today().isoformat(),
-    })
+    results.update(
+        {
+            "version": version,
+            "scores": metrics,
+            "score": score,
+            "date": date.today().isoformat(),
+        }
+    )
     results.setdefault("reviewer", "Automated")
 
     results_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")

--- a/scripts/refresh_link_cache.py
+++ b/scripts/refresh_link_cache.py
@@ -5,19 +5,21 @@ import re
 import urllib.request
 import urllib.error
 
-CACHE_FILE = os.path.join('docs', 'link_cache.txt')
-ROOT = os.path.join('docs', 'external')
+CACHE_FILE = os.path.join("docs", "link_cache.txt")
+ROOT = os.path.join("docs", "external")
+
 
 def collect_links():
     links = set()
     for dirpath, _, filenames in os.walk(ROOT):
         for name in filenames:
-            if not name.endswith('.md'):
+            if not name.endswith(".md"):
                 continue
-            with open(os.path.join(dirpath, name), 'r', encoding='utf-8') as f:
+            with open(os.path.join(dirpath, name), "r", encoding="utf-8") as f:
                 for match in re.findall(r'https?://[^\s)"\',]+', f.read()):
                     links.add(match)
     return sorted(links)
+
 
 def check_link(url: str) -> int:
     """Return the HTTP status code for ``url``.
@@ -50,13 +52,15 @@ def check_link(url: str) -> int:
     except Exception:
         return 0
 
+
 def main() -> None:
     links = collect_links()
-    with open(CACHE_FILE, 'w', encoding='utf-8') as cache:
+    with open(CACHE_FILE, "w", encoding="utf-8") as cache:
         for url in links:
             status = check_link(url)
             cache.write(f"{url} {status}\n")
     print(f"Updated {CACHE_FILE} with {len(links)} entries")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/scripts/update_source_index.py
+++ b/scripts/update_source_index.py
@@ -1,62 +1,83 @@
 #!/usr/bin/env python3
 """Regenerate docs/source_index.json from external doc stubs."""
-import json, os, re, datetime
+import json
+import os
+import re
+import datetime
 
-ROOT = os.path.join('docs', 'external')
+ROOT = os.path.join("docs", "external")
+
 
 def parse_stub(path):
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         text = f.read()
-    name_match = re.search(r'^#\s+(.*)', text, re.MULTILINE)
-    url_match = re.search(r'\*\*URL:\*\*\s*(\S+)', text)
-    rel_match = re.search(r'\*\*Relevance:\*\*\s*([^\n]+)', text)
-    used_match = re.search(r'\*\*Used by Agents:\*\*\s*([^\n]+)', text)
-    desc_match = re.search(r'## Description\n([^\n]+)', text)
+    name_match = re.search(r"^#\s+(.*)", text, re.MULTILINE)
+    url_match = re.search(r"\*\*URL:\*\*\s*(\S+)", text)
+    rel_match = re.search(r"\*\*Relevance:\*\*\s*([^\n]+)", text)
+    used_match = re.search(r"\*\*Used by Agents:\*\*\s*([^\n]+)", text)
+    desc_match = re.search(r"## Description\n([^\n]+)", text)
     name = name_match.group(1).strip() if name_match else os.path.basename(path)[:-3]
-    url = url_match.group(1).strip() if url_match else ''
-    tags = [t.strip() for t in re.split(r'[ ,]+', rel_match.group(1).strip())] if rel_match else []
-    used = [u.strip() for u in re.split(r'[ ,]+', used_match.group(1).strip())] if used_match else []
-    description = desc_match.group(1).strip() if desc_match else ''
+    url = url_match.group(1).strip() if url_match else ""
+    tags = (
+        [t.strip() for t in re.split(r"[ ,]+", rel_match.group(1).strip())]
+        if rel_match
+        else []
+    )
+    used = (
+        [u.strip() for u in re.split(r"[ ,]+", used_match.group(1).strip())]
+        if used_match
+        else []
+    )
+    description = desc_match.group(1).strip() if desc_match else ""
     return {
-        'name': name,
-        'link': url,
-        'description': description,
-        'used_by': used,
-        'tags': tags,
-        'last_reviewed': datetime.date.today().isoformat(),
-        'type': 'external'
+        "name": name,
+        "link": url,
+        "description": description,
+        "used_by": used,
+        "tags": tags,
+        "last_reviewed": datetime.date.today().isoformat(),
+        "type": "external",
     }
 
+
 def collect_existing_core(index_path):
-    with open(index_path, 'r', encoding='utf-8') as f:
+    with open(index_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    core = [s for s in data.get('sources', []) if s.get('type') != 'external']
-    meta = data.get('metadata', {})
+    core = [s for s in data.get("sources", []) if s.get("type") != "external"]
+    meta = data.get("metadata", {})
     return core, meta
 
+
 def main():
-    index_path = os.path.join('docs', 'source_index.json')
+    index_path = os.path.join("docs", "source_index.json")
     core_sources, meta = collect_existing_core(index_path)
     ext_sources = []
     names_seen = set()
     links_seen = set()
     for root, _, files in os.walk(ROOT):
         for fname in files:
-            if not fname.endswith('.md'):
+            if not fname.endswith(".md"):
                 continue
             stub = parse_stub(os.path.join(root, fname))
-            name = stub.get('name')
-            link = stub.get('link')
+            name = stub.get("name")
+            link = stub.get("link")
             if name in names_seen or (link and link in links_seen):
                 continue
             names_seen.add(name)
             if link:
                 links_seen.add(link)
             ext_sources.append(stub)
-    meta['last_updated'] = datetime.date.today().isoformat()
-    with open(index_path, 'w', encoding='utf-8') as f:
-        json.dump({'sources': core_sources + sorted(ext_sources, key=lambda x: x['name']),
-                   'metadata': meta}, f, indent=2)
+    meta["last_updated"] = datetime.date.today().isoformat()
+    with open(index_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "sources": core_sources + sorted(ext_sources, key=lambda x: x["name"]),
+                "metadata": meta,
+            },
+            f,
+            indent=2,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,4 +2,3 @@
 
 # This file ensures the tests package is discoverable when using pytest
 # and can host shared test utilities in the future.
-

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,25 +1,29 @@
 import unittest
 from o3research.agents.research_agent import ResearchAgent
+
 try:
     from o3research.agents.config_agent import ConfigAgent  # type: ignore
+
     YAML_AVAILABLE = True
 except Exception:
     YAML_AVAILABLE = False
 
+
 class TestAgents(unittest.TestCase):
     def test_research_agent(self):
         agent = ResearchAgent()
-        result = agent.run('ai marketing')
-        self.assertIn('researched', result)
+        result = agent.run("ai marketing")
+        self.assertIn("researched", result)
 
     def test_config_agent_load(self):
         if not YAML_AVAILABLE:
-            self.skipTest('yaml library not available')
+            self.skipTest("yaml library not available")
         agent = ConfigAgent()
         settings = agent.load_settings()
         self.assertIsInstance(settings, dict)
-        result = agent.run('')
-        self.assertTrue(result.startswith('ConfigAgent loaded'))
+        result = agent.run("")
+        self.assertTrue(result.startswith("ConfigAgent loaded"))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agents_extra.py
+++ b/tests/test_agents_extra.py
@@ -9,37 +9,37 @@ from o3research.agents.governance_agent import GovernanceAgent
 class TestExtraAgents(unittest.TestCase):
     def test_content_agent(self):
         agent = ContentAgent()
-        output = agent.run('LLM applications')
-        self.assertIn('blog post', output)
+        output = agent.run("LLM applications")
+        self.assertIn("blog post", output)
 
     def test_analytics_agent(self):
         agent = AnalyticsAgent()
-        output = agent.run('metrics data')
-        self.assertIn('analyzed data', output)
+        output = agent.run("metrics data")
+        self.assertIn("analyzed data", output)
 
     def test_ab_testing_agent_selects_best_variant(self):
         agent = AbTestingAgent()
         variants = {
-            'A': {'clicks': 100, 'conversions': 5},
-            'B': {'clicks': 120, 'conversions': 20},
-            'C': {'clicks': 50, 'conversions': 5},
+            "A": {"clicks": 100, "conversions": 5},
+            "B": {"clicks": 120, "conversions": 20},
+            "C": {"clicks": 50, "conversions": 5},
         }
         result = agent.run(variants)
-        self.assertIn('B', result)
+        self.assertIn("B", result)
 
     def test_governance_agent_detects_stale_heartbeat(self):
         agent = GovernanceAgent()
-        agent.record_heartbeat('AnalyticsAgent', time.time() - 31)
-        result = agent.run('ok')
-        self.assertIn('ALERT', result)
-        self.assertIn('AnalyticsAgent', result)
+        agent.record_heartbeat("AnalyticsAgent", time.time() - 31)
+        result = agent.run("ok")
+        self.assertIn("ALERT", result)
+        self.assertIn("AnalyticsAgent", result)
 
     def test_governance_agent_no_alert_for_recent_heartbeat(self):
         agent = GovernanceAgent()
-        agent.record_heartbeat('ContentAgent')
-        result = agent.run('ok')
-        self.assertNotIn('ALERT', result)
+        agent.record_heartbeat("ContentAgent")
+        result = agent.run("ok")
+        self.assertNotIn("ALERT", result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,34 +3,39 @@ from o3research.core.event_bus import EventBus
 from o3research.core.async_event_bus import AsyncEventBus
 from o3research.core.metrics import MetricsCollector
 import asyncio
+
 try:
     import yaml  # type: ignore
+
     YAML_AVAILABLE = True
 except Exception:
     YAML_AVAILABLE = False
+
 
 class TestEventBus(unittest.TestCase):
     def test_publish_subscribe(self):
         bus = EventBus()
         received = []
-        bus.subscribe('topic', lambda m: received.append(m))
-        bus.publish('topic', 'hello')
-        self.assertEqual(received, ['hello'])
+        bus.subscribe("topic", lambda m: received.append(m))
+        bus.publish("topic", "hello")
+        self.assertEqual(received, ["hello"])
 
     def test_async_publish_subscribe(self):
         bus = AsyncEventBus()
         received = []
+
         async def handler(msg: str) -> None:
             received.append(msg)
-        bus.subscribe('topic', handler)
-        asyncio.run(bus.publish('topic', 'async'))
-        self.assertEqual(received, ['async'])
+
+        bus.subscribe("topic", handler)
+        asyncio.run(bus.publish("topic", "async"))
+        self.assertEqual(received, ["async"])
 
     def test_publish_no_subscribers(self):
         """Publishing to a topic with no subscribers should not raise."""
         bus = EventBus()
         try:
-            bus.publish('empty', 'msg')
+            bus.publish("empty", "msg")
         except Exception as exc:  # pragma: no cover - should not happen
             self.fail(f"Publish raised unexpectedly: {exc}")
 
@@ -38,31 +43,31 @@ class TestEventBus(unittest.TestCase):
         bus = EventBus()
 
         def bad1(_: str) -> None:
-            raise ValueError('first')
+            raise ValueError("first")
 
         def bad2(_: str) -> None:
-            raise RuntimeError('second')
+            raise RuntimeError("second")
 
-        bus.subscribe('topic', bad1)
-        bus.subscribe('topic', bad2)
+        bus.subscribe("topic", bad1)
+        bus.subscribe("topic", bad2)
 
         with self.assertRaises(ValueError):
-            bus.publish('topic', 'data')
+            bus.publish("topic", "data")
 
     def test_async_publish_multiple_exceptions(self):
         bus = AsyncEventBus()
 
         async def bad1(_: str) -> None:
-            raise ValueError('first')
+            raise ValueError("first")
 
         async def bad2(_: str) -> None:
-            raise RuntimeError('second')
+            raise RuntimeError("second")
 
-        bus.subscribe('topic', bad1)
-        bus.subscribe('topic', bad2)
+        bus.subscribe("topic", bad1)
+        bus.subscribe("topic", bad2)
 
         with self.assertRaises(ValueError):
-            asyncio.run(bus.publish('topic', 'data'))
+            asyncio.run(bus.publish("topic", "data"))
 
 
 class TestMetricsCollector(unittest.TestCase):
@@ -77,15 +82,15 @@ class TestMetricsCollector(unittest.TestCase):
             returning_customers=5,
         )
         result = mc.collect()
-        self.assertEqual(result['impressions'], 1000)
-        self.assertEqual(result['clicks'], 100)
-        self.assertAlmostEqual(result['CTR'], 0.1)
-        self.assertAlmostEqual(result['CPC'], 0.5)
-        self.assertAlmostEqual(result['ConversionRate'], 0.1)
-        self.assertAlmostEqual(result['ROAS'], 4.0)
-        self.assertAlmostEqual(result['CLV'], 20.0)
-        self.assertAlmostEqual(result['CPA'], 5.0)
-        self.assertAlmostEqual(result['RetentionRate'], 0.5)
+        self.assertEqual(result["impressions"], 1000)
+        self.assertEqual(result["clicks"], 100)
+        self.assertAlmostEqual(result["CTR"], 0.1)
+        self.assertAlmostEqual(result["CPC"], 0.5)
+        self.assertAlmostEqual(result["ConversionRate"], 0.1)
+        self.assertAlmostEqual(result["ROAS"], 4.0)
+        self.assertAlmostEqual(result["CLV"], 20.0)
+        self.assertAlmostEqual(result["CPA"], 5.0)
+        self.assertAlmostEqual(result["RetentionRate"], 0.5)
 
     def test_zero_division(self):
         mc = MetricsCollector()
@@ -98,33 +103,34 @@ class TestMetricsCollector(unittest.TestCase):
             returning_customers=0,
         )
         result = mc.collect()
-        self.assertEqual(result['CTR'], 0.0)
-        self.assertEqual(result['CPC'], 0.0)
-        self.assertEqual(result['ConversionRate'], 0.0)
-        self.assertEqual(result['ROAS'], 0.0)
-        self.assertEqual(result['CLV'], 0.0)
-        self.assertEqual(result['CPA'], 0.0)
-        self.assertEqual(result['RetentionRate'], 0.0)
+        self.assertEqual(result["CTR"], 0.0)
+        self.assertEqual(result["CPC"], 0.0)
+        self.assertEqual(result["ConversionRate"], 0.0)
+        self.assertEqual(result["ROAS"], 0.0)
+        self.assertEqual(result["CLV"], 0.0)
+        self.assertEqual(result["CPA"], 0.0)
+        self.assertEqual(result["RetentionRate"], 0.0)
 
 
 class TestQueueLimits(unittest.TestCase):
     def test_async_queue_overflow(self):
         """Ensure queue overflow raises QueueFull if configured."""
         if not YAML_AVAILABLE:
-            self.skipTest('yaml library not available')
+            self.skipTest("yaml library not available")
 
-        with open('config/settings.yaml', 'r') as f:
+        with open("config/settings.yaml", "r") as f:
             settings = yaml.safe_load(f)
-        max_size = settings.get('max_queue_size')
+        max_size = settings.get("max_queue_size")
         if not max_size:
-            self.skipTest('max_queue_size not configured')
+            self.skipTest("max_queue_size not configured")
 
         q = asyncio.Queue(maxsize=max_size)
         for i in range(max_size):
             q.put_nowait(i)
 
         with self.assertRaises(asyncio.QueueFull):
-            q.put_nowait('overflow')
+            q.put_nowait("overflow")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,6 +1,7 @@
 import unittest
 from o3research.core.evaluation import evaluate
 
+
 class TestEvaluation(unittest.TestCase):
     def test_weighted_score_full(self):
         metrics = {
@@ -29,6 +30,7 @@ class TestEvaluation(unittest.TestCase):
         }
         score = evaluate(metrics)
         self.assertEqual(score, 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,7 @@ YAML_AVAILABLE = importlib.util.find_spec("yaml") is not None
 if YAML_AVAILABLE:
     from o3research.mcp_server import MCPServer
 
+
 @unittest.skipUnless(YAML_AVAILABLE, "yaml library not available")
 class TestMCPServer(unittest.TestCase):
     def setUp(self) -> None:
@@ -36,6 +37,7 @@ class TestMCPServer(unittest.TestCase):
         settings_count = len(self.server.config_agent.load_settings())
         result = self.server.route("config", "")
         self.assertEqual(result, f"ConfigAgent loaded {settings_count} settings")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_meta_json.py
+++ b/tests/test_meta_json.py
@@ -1,26 +1,30 @@
 import unittest
 import json
 
+
 class TestMetaEvaluationFile(unittest.TestCase):
     def test_required_sections_present(self):
-        with open('docs/meta/meta_evaluation.json', 'r') as f:
+        with open("docs/meta/meta_evaluation.json", "r") as f:
             data = json.load(f)
-        self.assertIn('evaluation_metrics', data)
-        self.assertIn('evaluation_workflow', data)
-        self.assertIn('version_history', data)
+        self.assertIn("evaluation_metrics", data)
+        self.assertIn("evaluation_workflow", data)
+        self.assertIn("version_history", data)
+
 
 class TestPromptGenomeFile(unittest.TestCase):
     def test_active_version_present(self):
-        with open('VERSION') as vf:
+        with open("VERSION") as vf:
             version = vf.read().strip()
-        with open('docs/meta/prompt_genome.json', 'r') as f:
+        with open("docs/meta/prompt_genome.json", "r") as f:
             genome = json.load(f)
-        prompts = genome.get('prompt_genome', {}).get('prompts', [])
+        prompts = genome.get("prompt_genome", {}).get("prompts", [])
         found = any(
-            p.get('status') == 'active' and version in (p.get('id', '') + p.get('name', ''))
+            p.get("status") == "active"
+            and version in (p.get("id", "") + p.get("name", ""))
             for p in prompts
         )
-        self.assertTrue(found, f'Active prompt for version {version} not found')
+        self.assertTrue(found, f"Active prompt for version {version} not found")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,11 +1,13 @@
 import unittest
 from o3research import __version__
 
+
 class TestVersion(unittest.TestCase):
     def test_version_matches_file(self):
-        with open('VERSION') as vf:
+        with open("VERSION") as vf:
             file_version = vf.read().strip()
         self.assertEqual(__version__, file_version)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- configure flake8 and black
- enable black and flake8 in pre-commit
- run black and flake8 in CI
- format existing code with black

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 "docs/**/*.md" "!docs/legacy/**"`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash -c 'REQUIRED_FILES=("docs/prompt/prompt_kernel_v3.5.md" "docs/meta/prompt_evolution_log/v3.5.yaml" "docs/meta/meta_evaluation.json" "docs/meta/prompt_genome.json" "docs/source_index.json" "README.md" "CHANGELOG.md" "tests/golden_prompts/test_prompt_coordinator.md" "tests/golden_prompts/test_memory_reflection.md" "tests/golden_prompts/test_kpi_optimization.md"); for f in "${REQUIRED_FILES[@]}"; do [ -f "$f" ] && echo "Found $f" || { echo "Missing $f"; exit 1; }; done'`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- `test -f docs/performance_marketing/reforge_growth_loops.md`
- `test -f docs/legacy/prompt/prompt_kernel_v3.4.md`
- `test -f docs/meta/prompt_genome.json`
- `bash /tmp/version_check.sh`
- `bash -c 'JSON_VERSION=$(jq -r '.version' docs/meta/evaluation_results.json); FILE_VERSION=$(tr -d "[:space:]" < VERSION); [ "$JSON_VERSION" = "$FILE_VERSION" ] && echo match'`
- `flake8`
- `black --check .`
- `python -m unittest discover tests`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68466a7bbb6c833394cdac0065ca736f