### PR TITLE
Fix merge commit prefix check

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%s)
           echo "Latest commit message: $COMMIT_MSG"
+          if [[ "$COMMIT_MSG" =~ ^Merge ]]; then
+            echo "✅ Merge commit detected, skipping prefix check"
+            exit 0
+          fi
           if ! echo "$COMMIT_MSG" | grep -Eq '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert):'; then
             echo "❌ Commit message must start with an approved prefix"
             exit 1


### PR DESCRIPTION
## Summary
- skip commit message prefix validation for merge commits in CI

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `CONFIG='{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
  find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "$CONFIG"`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- checked required files exist
- verified version consistency
- `bash scripts/validate_golden_prompts.sh`


------
https://chatgpt.com/codex/tasks/task_b_68468768497c8333b789bd97c4800374