### PR TITLE
fix: correct links in world agent integration doc

### DIFF
--- a/docs/world_agent_integration.md
+++ b/docs/world_agent_integration.md
@@ -9,7 +9,7 @@ This guide outlines how external agents can interface with the ADK repository an
 
 ## Integration Steps
 1. **Repository Access** — Connect via GitHub or clone the repo locally. Reference key files such as `docs/prompt/prompt_kernel_v3.5.md` and `docs/meta/prompt_genome.json`.
-2. **Event Bus Setup** — Publish and subscribe to the AsyncEventBus channels described in [Agent System Overview](docs/agent_system_overview.md). Typical topics include `campaign.launch`, `analysis.report`, `config.update`, and `heartbeat.check`.
+2. **Event Bus Setup** — Publish and subscribe to the AsyncEventBus channels described in [Agent System Overview](agent_system_overview.md). Typical topics include `campaign.launch`, `analysis.report`, `config.update`, and `heartbeat.check`.
 3. **Shared Memory** — Read and write semantic data using the mechanisms in `src/core/semantic_cache.py`. Agents should store embeddings or summaries for reuse by others.
 4. **PromptOps Workflow** — Route any prompt or configuration changes through the ConfigAgent. CI validation ensures that updates are tracked in `prompt_evolution_log/v3.5.yaml`.
 
@@ -29,4 +29,4 @@ src/agents/           # Reference agent implementations
 - `config.update`
 - `heartbeat.check`
 
-These topics enable real-time collaboration and monitoring. See [72-Hour Campaign Simulation](docs/simulations/72hr_campaign_sim.md) for a practical workflow example.
+These topics enable real-time collaboration and monitoring. See [72-Hour Campaign Simulation](simulations/72hr_campaign_sim.md) for a practical workflow example.


### PR DESCRIPTION
## Summary
- correct relative links in `world_agent_integration.md`

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d '{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'`
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_684696b4a58883338148e211e6d5f26b