### PR TITLE
fix: make AsyncEventBus publish resilient to subscriber errors

### DIFF
--- a/o3research/core/async_event_bus.py
+++ b/o3research/core/async_event_bus.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import defaultdict
+from .logger import get_logger
 from .types import AsyncCallback
 
 
@@ -8,11 +9,16 @@ class AsyncEventBus:
 
     def __init__(self) -> None:
         self.subscribers: dict[str, list[AsyncCallback]] = defaultdict(list)
+        self.logger = get_logger(self.__class__.__name__)
 
     def subscribe(self, topic: str, callback: AsyncCallback) -> None:
+        self.logger.debug("Subscriber added to %s", topic)
         self.subscribers[topic].append(callback)
 
     async def publish(self, topic: str, message: str) -> None:
         tasks = [callback(message) for callback in self.subscribers.get(topic, [])]
         if tasks:
-            await asyncio.gather(*tasks)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    self.logger.error("Error in subscriber for %s: %s", topic, result)


### PR DESCRIPTION
## Summary
- add a logger to `AsyncEventBus`
- log errors raised by subscribers instead of propagating them
- ensure async publish runs all callbacks and logs failures
- update unit test for new behaviour

## Testing
- `black --check .`
- `flake8`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `yamllint` on YAML files
- `grep -RniE 'TODO:|Coming soon|placeholder' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy || true`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh`

------
https://chatgpt.com/codex/tasks/task_b_684697dfc4a88333a877cffa7780a0f3