### PR TITLE
refactor: use pathlib for report output paths

### DIFF
--- a/examples/ads_integration_workflow.py
+++ b/examples/ads_integration_workflow.py
@@ -1,5 +1,7 @@
 """Example workflow integrating MetricsCollector and ReportGenerator."""
 
+from pathlib import Path
+
 from o3research.core.metrics import MetricsCollector
 from o3research.core.reporting import ReportGenerator
 
@@ -17,7 +19,8 @@ def main() -> None:
     metrics = collector.collect()
 
     reporter = ReportGenerator()
-    reporter.export_csv(metrics, "ads_metrics.csv")
+    output_path = Path("ads_metrics.csv")
+    reporter.export_csv(metrics, output_path)
     print("Metrics exported to ads_metrics.csv")
 
 

--- a/o3research/core/reporting.py
+++ b/o3research/core/reporting.py
@@ -1,5 +1,6 @@
 import csv
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 
 
 class ReportGenerator:
@@ -15,7 +16,9 @@ class ReportGenerator:
         return "\n".join(lines)
 
     def export_csv(
-        self, metrics: Mapping[str, float] | Iterable[Mapping[str, float]], path: str
+        self,
+        metrics: Mapping[str, float] | Iterable[Mapping[str, float]],
+        path: str | Path,
     ) -> None:
         """Write metrics to a CSV file."""
         if isinstance(metrics, Mapping):
@@ -26,7 +29,7 @@ class ReportGenerator:
                 raise ValueError("No metrics to export")
 
         fieldnames = list(rows[0].keys())
-        with open(path, "w", newline="") as f:
+        with Path(path).open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(rows)


### PR DESCRIPTION
# 🚀 Pull Request Summary - v3.5.7

## 📋 Description of Changes
- refactor `ReportGenerator.export_csv` to accept `str | Path` and open files via `Path.open`
- update `ads_integration_workflow.py` to pass a `Path`

---

## 🗂 Affected Files (v3.5.7)
<!-- Check all that apply -->

### Core Files
- [ ] `docs/prompt/prompt_kernel_v3.5.md`
- [ ] `docs/meta/prompt_evolution_log/v3.5.yaml`
- [ ] `docs/meta/meta_evaluation.json`

### Test Files
- [ ] `tests/golden_prompts/test_prompt_coordinator.md`
- [ ] `tests/golden_prompts/test_memory_reflection.md`
- [ ] `tests/golden_prompts/test_kpi_optimization.md`

### Supporting Files
- [ ] `docs/source_index.json`
- [ ] `CHANGELOG.md`
- [ ] `README.md`

### CI/CD
- [ ] `.github/workflows/validate_repo.yml`
- [ ] `.github/pull_request_template.md`

---

## 🧪 Golden Prompt Integration
- [ ] Added test_prompt_coordinator.md to `/tests/golden_prompts/`
- [ ] Added test_memory_reflection.md to `/tests/golden_prompts/`
- [ ] Added test_kpi_optimization.md to `/tests/golden_prompts/`
- [ ] CI configured to detect and validate golden prompts
- [ ] Golden prompts align with v3.5.7 kernel strategy

---

## ✅ Validation Checklist
- [x] No `TODO:`, `Coming soon`, or `placeholder` remaining
- [x] Links (internal/external) validated
- [ ] `source_index.json` updated if new `.md` was added
- [ ] `CHANGELOG.md` updated with version bump
- [x] PR title follows format: `feat:` `fix:` `chore:` etc.
- [ ] Merge commits reworded (e.g., `chore: merge master into feature-X`) or squashed
- [ ] Golden prompts pass validation checks
- [x] All tests are passing

---

## 🧠 Notes & Context (optional)
<!-- Add context for reviewers or document intent -->

------
https://chatgpt.com/codex/tasks/task_b_68469924a31883338be46d30b4b2508f