### PR TITLE
Apply doc fixes and maintain tests

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,3 +1,5 @@
+# Configuration Directory
+
 This directory stores deployment configuration files used by ConfigAgent.
 - `settings.yaml` defines global parameters shared across agents.
 - `prompts/` can hold prompt templates separate from code.

--- a/docs/world_agent_integration.md
+++ b/docs/world_agent_integration.md
@@ -8,7 +8,7 @@ This guide outlines how external agents can interface with the ADK repository an
 - Ensure updates remain version-controlled through the Prompt Genome and CI checks.
 
 ## Integration Steps
-1. **Repository Access** — Connect via GitHub or clone the repo locally. Reference key files such as `docs/prompt/prompt_kernel_v3.5.md` and `docs/meta/prompt_genome.json`.
+1. **Repository Access** — Connect via GitHub or clone the repo locally. Reference key files such as `prompt/prompt_kernel_v3.5.md` and `meta/prompt_genome.json`.
 2. **Event Bus Setup** — Publish and subscribe to the AsyncEventBus channels described in [Agent System Overview](agent_system_overview.md). Typical topics include `campaign.launch`, `analysis.report`, `config.update`, and `heartbeat.check`.
 3. **Shared Memory** — Read and write semantic data using the mechanisms in `src/core/semantic_cache.py`. Agents should store embeddings or summaries for reuse by others.
 4. **PromptOps Workflow** — Route any prompt or configuration changes through the ConfigAgent. CI validation ensures that updates are tracked in `prompt_evolution_log/v3.5.yaml`.


### PR DESCRIPTION
## Summary
- fix relative doc link in world_agent_integration.md
- add heading to configuration docs

## Testing
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `find . -name "*.json" -print0 | xargs -0 -I {} sh -c 'jq . {} >/dev/null'`
- `find . -name "*.yml" -o -name "*.yaml" | xargs yamllint -d relaxed`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `flake8`
- `black --check .`
- `mypy o3research --install-types --non-interactive`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_684693a6d0608333aad72d1a14499c1c