### PR TITLE
Move YAML and TODO checks into scripts

### DIFF
--- a/.github/workflows/validate_repo.yml
+++ b/.github/workflows/validate_repo.yml
@@ -73,27 +73,12 @@ jobs:
           jq . docs/meta/meta_evaluation.json > /dev/null
 
       - name: Validate YAML files
-        run: |
-          echo "Validating YAML files..."
-          CONFIG='{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
-          find . -path ./node_modules -prune -o \( \
-            -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "$CONFIG"
+        # Extracted into a script to avoid complex quoting
+        run: bash scripts/validate_yaml.sh
 
       - name: Check for TODO, Coming soon, or placeholder
-        run: |
-          echo "Checking for incomplete work..."
-          matches=$(grep -RniE '(TODO|Coming soon|placeholder)' docs/ --include="*.md" --include="*.yaml" \
-            --include="*.yml" --exclude-dir=legacy | grep -viE '^\s*```|<!--.*-->')
-          if [ -n "$matches" ]; then
-            echo "$matches"
-            branch=$(git rev-parse --abbrev-ref HEAD)
-            if [ "$branch" = "master" ]; then
-              echo "❌ Detected incomplete work on master. Please resolve before merging."
-              exit 1
-            else
-              echo "⚠️ Incomplete work detected on $branch. Proceeding with warning."
-            fi
-          fi
+        # Moved to a script for readability
+        run: bash scripts/check_incomplete_work.sh
 
       - name: Validate Required Files Exist
         run: |

--- a/scripts/check_incomplete_work.sh
+++ b/scripts/check_incomplete_work.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fail CI if documentation contains unfinished sections.
+# Extracted from the CI workflow to avoid quoting pitfalls.
+set -euo pipefail
+
+echo "Checking for incomplete work..."
+matches=$(grep -RniE '(TODO|Coming soon|placeholder)' docs/ --include="*.md" --include="*.yaml" --include="*.yml" --exclude-dir=legacy | grep -viE '^\s*```|<!--.*-->')
+if [ -n "$matches" ]; then
+  echo "$matches"
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$branch" = "master" ]; then
+    echo "❌ Detected incomplete work on master. Please resolve before merging."
+    exit 1
+  else
+    echo "⚠️ Incomplete work detected on $branch. Proceeding with warning."
+  fi
+fi

--- a/scripts/validate_yaml.sh
+++ b/scripts/validate_yaml.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Validate YAML files using yamllint.
+# Extracted from the CI workflow to simplify quoting.
+set -euo pipefail
+
+CONFIG='{ extends: default, rules: {line-length: {max: 120, allow-non-breakable-inline-mappings: true}} }'
+
+echo "Validating YAML files..."
+find . -path ./node_modules -prune -o \( -name '*.yaml' -o -name '*.yml' \) -print0 | xargs -0 yamllint -d "$CONFIG"


### PR DESCRIPTION
## Summary
- move yamllint step to `scripts/validate_yaml.sh`
- move TODO check to `scripts/check_incomplete_work.sh`
- call the new scripts from the workflow and document why

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json > /dev/null`
- `jq . docs/meta/prompt_genome.json > /dev/null`
- `jq . docs/meta/meta_evaluation.json > /dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash -c '...validate required files...` (see log)
- `bash scripts/validate_versions.sh`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_6847618c61448333ae6e4ca592045d4c