### PR TITLE
docs: clarify link checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ markdownlint-cli2 "**/*.md" "#node_modules"
 grep -r "TODO\|Coming soon\|placeholder" --include="*.md" --include="*.json" --include="*.yml" --include="*.yaml" .
 # Rebuild source index and run offline link check
 python3 scripts/update_source_index.py
+# offline check defaults to warn-only mode
 bash scripts/offline_link_check.sh
+# enforce strict behavior with environment variable or flag
+STRICT_LINKS=1 bash scripts/offline_link_check.sh
+bash scripts/offline_link_check.sh --strict
   python scripts/refresh_link_cache.py
 ```
 

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -8,7 +8,7 @@ To maintain quality, reproducibility, and consistency, all contributions must fo
 - [ ] Affected files declared and justified
 - [ ] No stub sections remain
 - [ ] All `.md` files are linted (via markdownlint-cli2)
-- [ ] All links return HTTP 200
+- [ ] Run `bash scripts/offline_link_check.sh` to verify external links (warn-only by default). Use `STRICT_LINKS=1` or `--strict` to fail on warnings.
 - [ ] Genome version for prompts updated in `prompt_genome.json`
 - [ ] `CHANGELOG.md` contains a descriptive section of updates
 - [ ] `python scripts/generate_evaluation.py tests/sample_metrics.json` run to update evaluation results

--- a/docs/meta/release_checklist_v3.5.md
+++ b/docs/meta/release_checklist_v3.5.md
@@ -16,6 +16,8 @@
 
 ## 🔗 Link Integrity
 - [ ] Validate all links using `CI Validate O3 Repo`
+- [ ] Run `bash scripts/offline_link_check.sh` (warn-only by default)
+- [ ] Set `STRICT_LINKS=1` or pass `--strict` to fail on warnings
 - [ ] No broken external references or redirects
 
 ## 🔍 Prompt Review


### PR DESCRIPTION
## Summary
- mention warn-only default for `offline_link_check.sh` in README
- explain how to enable strict mode with `STRICT_LINKS=1` or `--strict`
- update contribution guide to reflect warn-only link checking
- revise release checklist link integrity section

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/validate_versions.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_684767283e4c83338599c54e55bb005b