### PR TITLE
Fix README and guide for TODO scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ To run validations locally:
 # Run markdown linting
 markdownlint-cli2 "**/*.md" "#node_modules"
 
-# Check for TODOs and placeholders
-grep -r "TODO\|Coming soon\|placeholder" --include="*.md" --include="*.json" --include="*.yml" --include="*.yaml" .
+# Check docs for TODOs and placeholders
+bash scripts/check_incomplete_work.sh
 # Rebuild source index and run offline link check
 python3 scripts/update_source_index.py
 # offline check defaults to warn-only mode

--- a/docs/contribution_guide.md
+++ b/docs/contribution_guide.md
@@ -9,9 +9,13 @@ To maintain quality, reproducibility, and consistency, all contributions must fo
 - [ ] No stub sections remain
 - [ ] All `.md` files are linted (via markdownlint-cli2)
 - [ ] Run `bash scripts/offline_link_check.sh` to verify external links (warn-only by default). Use `STRICT_LINKS=1` or `--strict` to fail on warnings.
+- [ ] `bash scripts/check_incomplete_work.sh` shows no to-do markers or temporary filler text in Markdown or YAML docs
+<!-- The script scans for TODO, Coming soon, or placeholder phrases -->
 - [ ] Genome version for prompts updated in `prompt_genome.json`
 - [ ] `CHANGELOG.md` contains a descriptive section of updates
 - [ ] `python scripts/generate_evaluation.py tests/sample_metrics.json` run to update evaluation results
+
+The incomplete work script scans only the `docs/` directory for Markdown and YAML files. JSON files are ignored.
 
 ## 📂 Required File Structure
 


### PR DESCRIPTION
## Summary
- clarify how to run the incomplete work check
- document what the script scans

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/validate_versions.sh`


------
https://chatgpt.com/codex/tasks/task_b_684769621e4483339d079071aa7b31e5