### PR TITLE
Add multi-row CSV export tests

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -31,6 +31,33 @@ class TestReportGenerator(unittest.TestCase):
         self.assertEqual(rows[0], ["clicks", "impressions"])
         self.assertEqual(rows[1], ["5", "10"])
 
+    def test_export_csv_multiple_rows(self):
+        rows_in = [
+            {"clicks": 5, "impressions": 10},
+            {"clicks": 7, "impressions": 14},
+        ]
+        rg = ReportGenerator()
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "metrics.csv"
+            rg.export_csv(rows_in, path)
+            with path.open() as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+
+        expected = [
+            ["clicks", "impressions"],
+            ["5", "10"],
+            ["7", "14"],
+        ]
+        self.assertEqual(rows, expected)
+
+    def test_export_csv_empty_list(self):
+        rg = ReportGenerator()
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "metrics.csv"
+            with self.assertRaises(ValueError):
+                rg.export_csv([], path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- [x] Ran `markdownlint-cli2`
- [x] Validated JSON and YAML
- [x] Checked incomplete work
- [x] Verified version consistency and required files
- [x] Linted with flake8 and black
- [x] Ran mypy type checks
- [x] Executed full test suite with coverage

## Summary
- expand `tests/test_reporting.py` with multi-row export and empty list error

## Testing
- `coverage run -m pytest`
- `coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68477578a75c83339891092ee251a442