### PR TITLE
Add test verifying __main__ block execution

### DIFF
--- a/docs/meta/evaluation_results.json
+++ b/docs/meta/evaluation_results.json
@@ -7,6 +7,6 @@
     "efficiency": 5
   },
   "reviewer": "QA Team",
-  "date": "2025-06-09",
+  "date": "2025-06-10",
   "score": 4.75
 }

--- a/tests/test_runpy_main.py
+++ b/tests/test_runpy_main.py
@@ -1,0 +1,16 @@
+import runpy
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_test_version_executes_main():
+    called = {"value": False}
+
+    def dummy():
+        called["value"] = True
+
+    test_file = Path(__file__).with_name("test_version.py")
+    with patch("unittest.main", dummy):
+        runpy.run_path(str(test_file), run_name="__main__")
+
+    assert called["value"], "unittest.main should have been called"


### PR DESCRIPTION
- [x] CI checks
- [x] Update evaluation results

## Summary
- test that running a test file via `runpy.run_path` executes the `__main__` block
- refresh evaluation results

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`
- `flake8`
- `black --check .`
- `mypy o3research`
- `pytest -q`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_684776af506c83339b62409ade4c3fb6