### PR TITLE
Add patch-based queue overflow tests

### DIFF
--- a/tests/test_core_dummy_yaml.py
+++ b/tests/test_core_dummy_yaml.py
@@ -1,0 +1,30 @@
+import importlib
+import runpy
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_async_queue_overflow_with_dummy_yaml():
+    dummy_yaml = types.ModuleType("yaml")
+    dummy_yaml.safe_load = lambda _: {"max_queue_size": 1}
+    with patch.dict("sys.modules", {"yaml": dummy_yaml}):
+        import tests.test_core as tc
+
+        importlib.reload(tc)
+        with patch.object(tc, "YAML_AVAILABLE", True):
+            case = tc.TestQueueLimits("test_async_queue_overflow")
+            case.test_async_queue_overflow()
+    importlib.reload(tc)
+
+
+def test_core_main_via_runpy():
+    called = {"value": False}
+
+    def dummy():
+        called["value"] = True
+
+    test_file = Path(__file__).with_name("test_core.py")
+    with patch("unittest.main", dummy):
+        runpy.run_path(str(test_file), run_name="__main__")
+    assert called["value"], "unittest.main should have been called"


### PR DESCRIPTION
## Summary
- verify queue overflow logic works with a dummy YAML module
- run `tests/test_core.py` via `runpy` to exercise the `__main__` block

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq`/`yamllint`/`bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_yaml.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_6847782d581c8333adb9ece989d62f80