### PR TITLE
test: ensure reporting test runs via runpy

### DIFF
--- a/tests/test_runpy_main.py
+++ b/tests/test_runpy_main.py
@@ -40,3 +40,16 @@ def test_test_meta_json_executes_main():
         runpy.run_path(str(test_file), run_name="__main__")
 
     assert called["value"], "unittest.main should have been called"
+
+
+def test_test_reporting_executes_main():
+    called = {"value": False}
+
+    def dummy():
+        called["value"] = True
+
+    test_file = Path(__file__).with_name("test_reporting.py")
+    with patch("unittest.main", dummy):
+        runpy.run_path(str(test_file), run_name="__main__")
+
+    assert called["value"], "unittest.main should have been called"


### PR DESCRIPTION
## Summary
- verify `tests/test_reporting.py` calls `unittest.main`

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `pip install -r requirements.txt`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68477cf0151083338d28e781cfea59eb