### PR TITLE
feat: add command dispatch with tests

### DIFF
--- a/o3research/core/__init__.py
+++ b/o3research/core/__init__.py
@@ -4,6 +4,7 @@ from .logger import get_logger
 from .reporting import ReportGenerator
 from .task_flow import TaskFlow
 from .executor import Executor
+from .command_dispatch import register_handler, dispatch, remove_handler, clear_handlers
 
 __all__ = [
     "EventBus",
@@ -12,4 +13,8 @@ __all__ = [
     "ReportGenerator",
     "TaskFlow",
     "Executor",
+    "register_handler",
+    "dispatch",
+    "remove_handler",
+    "clear_handlers",
 ]

--- a/o3research/core/command_dispatch.py
+++ b/o3research/core/command_dispatch.py
@@ -1,0 +1,30 @@
+"""Minimal command dispatch registry."""
+
+from typing import Any, Callable, Dict
+
+_HANDLERS: Dict[str, Callable[..., Any]] = {}
+
+
+def register_handler(command: str, handler: Callable[..., Any]) -> None:
+    """Register a callable handler for a command."""
+    if command in _HANDLERS:
+        raise KeyError(f"Handler already registered for {command}")
+    _HANDLERS[command] = handler
+
+
+def dispatch(command: str, *args: Any, **kwargs: Any) -> Any:
+    """Dispatch a command to its registered handler."""
+    handler = _HANDLERS.get(command)
+    if not handler:
+        return f"Unknown command: {command}"
+    return handler(*args, **kwargs)
+
+
+def remove_handler(command: str) -> None:
+    """Remove a registered handler if present."""
+    _HANDLERS.pop(command, None)
+
+
+def clear_handlers() -> None:
+    """Remove all registered handlers (primarily for tests)."""
+    _HANDLERS.clear()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,38 @@
+import unittest
+from o3research.core.command_dispatch import (
+    register_handler,
+    dispatch,
+    remove_handler,
+    clear_handlers,
+)
+
+
+class TestCommandDispatch(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_handlers()
+
+    def test_known_command_invokes_handler(self) -> None:
+        calls = []
+
+        def handler(arg: str) -> str:
+            calls.append(arg)
+            return "handled"
+
+        register_handler("ping", handler)
+        result = dispatch("ping", "data")
+        self.assertEqual(result, "handled")
+        self.assertEqual(calls, ["data"])
+
+    def test_unknown_command(self) -> None:
+        result = dispatch("missing")
+        self.assertEqual(result, "Unknown command: missing")
+
+    def test_remove_handler(self) -> None:
+        register_handler("ping", lambda: "ok")
+        remove_handler("ping")
+        result = dispatch("ping")
+        self.assertEqual(result, "Unknown command: ping")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement simple command dispatch registry
- export dispatch helpers from core package
- test registering, unknown command, and removing handlers

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json > /dev/null && jq . docs/meta/prompt_genome.json > /dev/null && jq . docs/meta/meta_evaluation.json > /dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `black --check .`
- `flake8`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`

------
https://chatgpt.com/codex/tasks/task_b_68478fd03eac833399d329947fdfe3ce