### PR TITLE
Add prompt loader tests

### DIFF
--- a/o3research/__init__.py
+++ b/o3research/__init__.py
@@ -3,6 +3,7 @@ from .agents.sample_agent import EchoAgent
 from .agents.research_agent import ResearchAgent
 from .core.task_flow import TaskFlow
 from .core.executor import Executor
+from .core.prompt_gen import get_prompt, DEFAULT_PROMPT
 
 import pathlib
 
@@ -17,5 +18,7 @@ __all__ = [
     "ResearchAgent",
     "TaskFlow",
     "Executor",
+    "get_prompt",
+    "DEFAULT_PROMPT",
     "__version__",
 ]

--- a/o3research/core/prompt_gen.py
+++ b/o3research/core/prompt_gen.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+DEFAULT_PROMPT = "Default prompt text"
+
+
+def get_prompt(path: Path | str = Path("prompt.txt")) -> str:
+    p = Path(path)
+    if p.exists():
+        return p.read_text(encoding="utf-8")
+    return DEFAULT_PROMPT

--- a/tests/test_prompt_gen.py
+++ b/tests/test_prompt_gen.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from o3research.core.prompt_gen import get_prompt, DEFAULT_PROMPT
+
+
+class TestPromptGen(unittest.TestCase):
+    def test_default_prompt_when_missing(self):
+        with patch.object(Path, "exists", return_value=False):
+            result = get_prompt(Path("missing.txt"))
+        self.assertEqual(result, DEFAULT_PROMPT)
+
+    def test_custom_prompt_from_file(self):
+        with patch.object(Path, "exists", return_value=True), patch.object(
+            Path, "read_text", return_value="custom"
+        ) as read_mock:
+            result = get_prompt(Path("file.txt"))
+            read_mock.assert_called_once_with(encoding="utf-8")
+        self.assertEqual(result, "custom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add simple prompt generator utility
- expose it in the package
- test both branches of get_prompt

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json >/dev/null && jq . docs/meta/prompt_genome.json >/dev/null && jq . docs/meta/meta_evaluation.json >/dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run --branch -m pytest`
- `coverage xml && coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68479555fd488333a81b64888e0c0bee