### PR TITLE
Add prompt manager tests

### DIFF
--- a/o3research/__init__.py
+++ b/o3research/__init__.py
@@ -4,6 +4,7 @@ from .agents.research_agent import ResearchAgent
 from .core.task_flow import TaskFlow
 from .core.executor import Executor
 from .core.prompt_gen import get_prompt, DEFAULT_PROMPT
+from .core.prompt_manager import PromptManager
 
 import pathlib
 
@@ -20,5 +21,6 @@ __all__ = [
     "Executor",
     "get_prompt",
     "DEFAULT_PROMPT",
+    "PromptManager",
     "__version__",
 ]

--- a/o3research/core/prompt_manager.py
+++ b/o3research/core/prompt_manager.py
@@ -1,0 +1,18 @@
+class PromptManager:
+    """Manage message history for prompts with optional summarization."""
+
+    def __init__(self, history_limit: int = 10) -> None:
+        self.history_limit = history_limit
+
+    def summarize_history(self, history: list[str]) -> list[str]:
+        """Return summarized history if it exceeds the limit.
+
+        The implementation collapses the oldest messages into a single summary
+        placeholder when the number of messages exceeds ``history_limit``.
+        """
+        if len(history) <= self.history_limit:
+            return history
+
+        summary_count = len(history) - (self.history_limit - 1)
+        summary = f"[{summary_count} messages summarized]"
+        return [summary] + history[-(self.history_limit - 1) :]

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,0 +1,23 @@
+import unittest
+
+from o3research.core.prompt_manager import PromptManager
+
+
+class TestPromptManager(unittest.TestCase):
+    def test_summarize_long_history(self):
+        mgr = PromptManager(history_limit=5)
+        history = [f"msg {i}" for i in range(10)]
+        result = mgr.summarize_history(history)
+        # Should reduce number of messages and include summary token
+        self.assertLess(len(result), len(history))
+        self.assertTrue(result[0].startswith("["))
+
+    def test_skip_summarization_for_short_history(self):
+        mgr = PromptManager(history_limit=5)
+        history = ["hello", "world"]
+        result = mgr.summarize_history(history)
+        self.assertEqual(result, history)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `PromptManager` helper for condensing long histories
- export `PromptManager` from package init
- test summarization branch and skip path

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json >/dev/null`
- `jq . docs/meta/prompt_genome.json >/dev/null`
- `jq . docs/meta/meta_evaluation.json >/dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68479781a0508333a955b88ec9729db4