### PR TITLE
Add Telemetry tests

### DIFF
--- a/o3research/core/__init__.py
+++ b/o3research/core/__init__.py
@@ -4,7 +4,13 @@ from .logger import get_logger
 from .reporting import ReportGenerator
 from .task_flow import TaskFlow
 from .executor import Executor
-from .command_dispatch import register_handler, dispatch, remove_handler, clear_handlers
+from .command_dispatch import (
+    register_handler,
+    dispatch,
+    remove_handler,
+    clear_handlers,
+)
+from .telemetry import TelemetryClient
 
 __all__ = [
     "EventBus",
@@ -13,6 +19,7 @@ __all__ = [
     "ReportGenerator",
     "TaskFlow",
     "Executor",
+    "TelemetryClient",
     "register_handler",
     "dispatch",
     "remove_handler",

--- a/o3research/core/telemetry.py
+++ b/o3research/core/telemetry.py
@@ -1,0 +1,26 @@
+import os
+from typing import Any, Callable, List, Dict
+
+
+class TelemetryClient:
+    """Simple telemetry client that buffers events until flushed."""
+
+    def __init__(self, collector: Callable[[Dict[str, Any]], None]) -> None:
+        self.collector = collector
+        self._buffer: List[Dict[str, Any]] = []
+
+    def log_event(self, event: Dict[str, Any]) -> None:
+        """Add *event* to the buffer if telemetry is enabled."""
+        if os.environ.get("TELEMETRY_ENABLED") == "1":
+            self._buffer.append(event)
+
+    def flush(self) -> None:
+        """Send buffered events to the collector and clear the buffer."""
+        for event in self._buffer:
+            self.collector(event)
+        self._buffer.clear()
+
+    @property
+    def buffer(self) -> List[Dict[str, Any]]:
+        """Return a copy of the current event buffer."""
+        return list(self._buffer)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from o3research.core.telemetry import TelemetryClient
+
+
+class DummyCollector:
+    def __init__(self) -> None:
+        self.events = []
+
+    def __call__(self, event):
+        self.events.append(event)
+
+
+class TestTelemetryClient(unittest.TestCase):
+    def test_logging_enabled(self):
+        collector = DummyCollector()
+        client = TelemetryClient(collector)
+        with patch.dict(os.environ, {"TELEMETRY_ENABLED": "1"}):
+            client.log_event({"type": "foo"})
+            self.assertEqual(client.buffer, [{"type": "foo"}])
+            client.flush()
+        self.assertEqual(collector.events, [{"type": "foo"}])
+        self.assertEqual(client.buffer, [])
+
+    def test_logging_disabled(self):
+        collector = DummyCollector()
+        client = TelemetryClient(collector)
+        with patch.dict(os.environ, {}, clear=True):
+            client.log_event({"type": "foo"})
+        with patch.dict(os.environ, {"TELEMETRY_ENABLED": "0"}):
+            client.log_event({"type": "bar"})
+        self.assertEqual(collector.events, [])
+        self.assertEqual(client.buffer, [])
+
+    def test_flush_resets_buffer(self):
+        collector = DummyCollector()
+        client = TelemetryClient(collector)
+        with patch.dict(os.environ, {"TELEMETRY_ENABLED": "1"}):
+            client.log_event({"type": "foo"})
+            client.log_event({"type": "bar"})
+            client.flush()
+            self.assertEqual(collector.events, [{"type": "foo"}, {"type": "bar"}])
+            self.assertEqual(client.buffer, [])


### PR DESCRIPTION
## Summary
- add simple `TelemetryClient` with buffering
- expose `TelemetryClient` in `o3research.core`
- verify telemetry behavior with environment variables

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh --warn-only`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_684798ad64b88333a8c3e8b9de801d9f