### PR TITLE
Add context tests

### DIFF
--- a/o3research/__init__.py
+++ b/o3research/__init__.py
@@ -5,6 +5,7 @@ from .core.task_flow import TaskFlow
 from .core.executor import Executor
 from .core.prompt_gen import get_prompt, DEFAULT_PROMPT
 from .core.prompt_manager import PromptManager
+from .core.context import Context
 
 import pathlib
 
@@ -22,5 +23,6 @@ __all__ = [
     "get_prompt",
     "DEFAULT_PROMPT",
     "PromptManager",
+    "Context",
     "__version__",
 ]

--- a/o3research/core/context.py
+++ b/o3research/core/context.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict
+
+
+class Context:
+    """Simple key-value store for sharing data between components."""
+
+    def __init__(self, initial: Dict[str, Any] | None = None) -> None:
+        if initial is not None and not isinstance(initial, dict):
+            raise TypeError("initial must be a dict")
+        self._data: Dict[str, Any] = dict(initial or {})
+
+    def update(self, data: Dict[str, Any]) -> None:
+        if not isinstance(data, dict):
+            raise TypeError("data must be a dict")
+        self._data.update(data)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self._data)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,21 @@
+import unittest
+
+from o3research.core.context import Context
+
+
+class TestContext(unittest.TestCase):
+    def test_update_overwrites(self) -> None:
+        ctx = Context({"a": 1, "b": 2})
+        ctx.update({"b": 3, "c": 4})
+        self.assertEqual(ctx["a"], 1)
+        self.assertEqual(ctx["b"], 3)
+        self.assertEqual(ctx["c"], 4)
+
+    def test_update_invalid_type(self) -> None:
+        ctx = Context()
+        with self.assertRaises(TypeError):
+            ctx.update([("a", 1)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `Context` class and export in package
- test overwriting updates and invalid update input

## Testing
- `flake8`
- `black --check .`
- `mypy o3research`
- `pytest -q`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `bash scripts/offline_link_check.sh --warn-only`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_versions.sh`
- `bash scripts/validate_golden_prompts.sh`


------
https://chatgpt.com/codex/tasks/task_b_68479ca22fd8833384e3c5a2331335cf