### PR TITLE
Add test for AsyncEventBus no-subscriber case

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,12 @@ class TestEventBus(unittest.TestCase):
         except Exception as exc:  # pragma: no cover - should not happen
             self.fail(f"Publish raised unexpectedly: {exc}")
 
+    def test_async_publish_no_subscribers(self) -> None:
+        """Async publish should silently succeed when there are no subscribers."""
+        bus = AsyncEventBus()
+        with self.assertNoLogs(bus.logger, level="DEBUG"):
+            asyncio.run(bus.publish("empty", "msg"))
+
     def test_publish_multiple_exceptions(self):
         bus = EventBus()
 


### PR DESCRIPTION
- [x] Tests pass
- [x] Lint checks pass

Added an async test verifying `AsyncEventBus.publish` does not log or raise when the topic has no subscribers.

------
https://chatgpt.com/codex/tasks/task_b_6847a551196883339197bd0cdcf5ad8a