### PR TITLE
Add runpy module tests

### DIFF
--- a/tests/test_runpy_modules.py
+++ b/tests/test_runpy_modules.py
@@ -1,0 +1,19 @@
+import io
+import runpy
+from contextlib import redirect_stdout
+
+
+def test_run_mcp_server_via_run_module() -> None:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        runpy.run_module("o3research.mcp_server", run_name="__main__")
+    lines = [line for line in buffer.getvalue().splitlines() if line.strip()]
+    assert len(lines) == 6
+
+
+def test_run_sample_agent_via_run_module() -> None:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        runpy.run_module("o3research.agents.sample_agent", run_name="__main__")
+    output = buffer.getvalue()
+    assert "Hello world" in output


### PR DESCRIPTION
## Summary
- test running modules via runpy.run_module

## Testing
- `bash scripts/setup_env.sh`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_versions.sh`
- `bash scripts/validate_golden_prompts.sh`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `coverage run -m pytest`
- `coverage xml && coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_6847a9abe1ac83338997551beaa51911