### PR TITLE
Add missing Context tests

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,17 @@ class TestContext(unittest.TestCase):
         with self.assertRaises(TypeError):
             ctx.update([("a", 1)])
 
+    def test_contains_getitem_to_dict(self) -> None:
+        ctx = Context({"x": 42})
+        self.assertTrue("x" in ctx)
+        self.assertFalse("y" in ctx)
+        self.assertEqual(ctx["x"], 42)
+        self.assertEqual(ctx.to_dict(), {"x": 42})
+
+    def test_init_invalid_type(self) -> None:
+        with self.assertRaises(TypeError):
+            Context([("a", 1)])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- cover Context contains/getitem/to_dict helpers
- validate error on invalid initial data

## Testing
- `coverage run -m pytest`
- `bash scripts/validate_versions.sh`
- `bash scripts/offline_link_check.sh --warn-only`

------
https://chatgpt.com/codex/tasks/task_b_6847abd76de48333a350e36bb35bec6e