### PR TITLE
test: check duplicate handler registration

### DIFF
--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -33,6 +33,12 @@ class TestCommandDispatch(unittest.TestCase):
         result = dispatch("ping")
         self.assertEqual(result, "Unknown command: ping")
 
+    def test_register_handler_duplicate(self) -> None:
+        """Registering the same command twice should raise KeyError."""
+        register_handler("ping", lambda: "ok")
+        with self.assertRaisesRegex(KeyError, "Handler already registered for ping"):
+            register_handler("ping", lambda: "duplicate")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add test for duplicate register_handler calls to check KeyError

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `coverage run -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_6847acf17994833382e8bf15df57c2e0