### PR TITLE
Add runpy tests for agent modules

### DIFF
--- a/tests/test_runpy_agents.py
+++ b/tests/test_runpy_agents.py
@@ -1,0 +1,45 @@
+import io
+import runpy
+from contextlib import redirect_stdout
+
+
+def _capture_run(module_name: str) -> str:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        runpy.run_module(module_name, run_name="__main__")
+    return buffer.getvalue()
+
+
+def test_run_research_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.research_agent")
+    assert "researched" in output
+
+
+def test_run_content_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.content_agent")
+    assert "blog post" in output
+
+
+def test_run_engagement_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.engagement_agent")
+    assert output == ""
+
+
+def test_run_optimization_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.optimization_agent")
+    assert output == ""
+
+
+def test_run_analytics_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.analytics_agent")
+    assert output == ""
+
+
+def test_run_campaign_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.campaign_agent")
+    assert "campaign" in output
+
+
+def test_run_governance_agent_via_run_module() -> None:
+    output = _capture_run("o3research.agents.governance_agent")
+    assert "reviewed status" in output


### PR DESCRIPTION
## Summary
- add `test_runpy_agents.py` to exercise agent modules with `runpy.run_module`

## Testing
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`


------
https://chatgpt.com/codex/tasks/task_b_6847ae0bc1d88333b34d1d6c5ef5ef6e