### PR TITLE
feat: add Google Ads campaign agent

### DIFF
--- a/docs/performance_marketing/README.md
+++ b/docs/performance_marketing/README.md
@@ -12,3 +12,14 @@ This directory compiles research notes and strategies for data-driven advertisin
 - `reforge_growth_loops.md`
 - `skai_roi_optimization.md`
 - `smartly_creative_ai.md`
+
+## Usage
+
+Use `GoogleAdsCampaignAgent` to quickly create a campaign outline:
+
+```python
+from o3research.marketing import GoogleAdsCampaignAgent
+
+agent = GoogleAdsCampaignAgent()
+print(agent.run("example offer"))
+```

--- a/o3research/agents/agent_registry.py
+++ b/o3research/agents/agent_registry.py
@@ -1,5 +1,7 @@
 from typing import Type, Dict
 
+from ..marketing.google_ads_agent import GoogleAdsCampaignAgent
+
 # simple registry mapping names to agent classes
 _AGENT_REGISTRY: Dict[str, Type] = {}
 
@@ -22,3 +24,9 @@ def get_agent(name: str) -> Type:
 def clear_registry() -> None:
     """Remove all registered agents (useful for tests)."""
     _AGENT_REGISTRY.clear()
+    # re-register built-in agents
+    register_agent("google_ads", GoogleAdsCampaignAgent)
+
+
+# register default agents
+register_agent("google_ads", GoogleAdsCampaignAgent)

--- a/o3research/marketing/__init__.py
+++ b/o3research/marketing/__init__.py
@@ -1,0 +1,5 @@
+"""Marketing agents package."""
+
+from .google_ads_agent import GoogleAdsCampaignAgent
+
+__all__ = ["GoogleAdsCampaignAgent"]

--- a/o3research/marketing/google_ads_agent.py
+++ b/o3research/marketing/google_ads_agent.py
@@ -1,0 +1,25 @@
+from ..core.base_agent import BaseAgent
+
+
+class GoogleAdsCampaignAgent(BaseAgent):
+    """Generate a simple Google Ads campaign plan."""
+
+    def __init__(self) -> None:
+        super().__init__(name="GoogleAdsCampaignAgent")
+
+    def run(self, offer: str) -> str:
+        """Return a basic campaign plan for the given product or offer."""
+        summary_ref = "docs/performance_marketing/google_insights_summary.md lines 8-21"
+        plan = (
+            f"Plan for {offer}:\n"
+            "- Channels: Search, Display\n"
+            "- Keywords: focus on smart bidding and audience segments\n"
+            "- Ads: enable cross-channel attribution\n"
+            f"(See {summary_ref})"
+        )
+        return plan
+
+
+if __name__ == "__main__":  # pragma: no cover
+    agent = GoogleAdsCampaignAgent()
+    print(agent.run("new SaaS"))

--- a/tests/golden_prompts/test_google_ads_campaign.md
+++ b/tests/golden_prompts/test_google_ads_campaign.md
@@ -1,0 +1,14 @@
+# Google Ads Campaign Plan
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
+Generate a simple Google Ads campaign outline for a new product launch.
+
+### EXPECTED
+- Includes channels, keywords, and ad examples
+- References audience segmentation and bidding strategies
+- Mentions cross-channel attribution setup
+
+### NOTES
+Prompt Kernel: v3.5.7
+**Tags:** google ads, campaign plan

--- a/tests/test_google_ads_agent.py
+++ b/tests/test_google_ads_agent.py
@@ -1,0 +1,20 @@
+import unittest
+
+from o3research.marketing import GoogleAdsCampaignAgent
+from o3research.agents.agent_registry import get_agent
+
+
+class TestGoogleAdsCampaignAgent(unittest.TestCase):
+    def test_plan_generation(self) -> None:
+        agent = GoogleAdsCampaignAgent()
+        plan = agent.run("cloud service")
+        self.assertIn("Search", plan)
+        self.assertIn("docs/performance_marketing/google_insights_summary.md", plan)
+
+    def test_registry_lookup(self) -> None:
+        cls = get_agent("google_ads")
+        self.assertIs(cls, GoogleAdsCampaignAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `GoogleAdsCampaignAgent` to generate basic plans
- export marketing agents
- register new agent in the registry
- document agent usage
- add golden prompt and tests

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json >/dev/null && jq . docs/meta/prompt_genome.json >/dev/null && jq . docs/meta/meta_evaluation.json >/dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_6847b2a0e2908333842b2112464290da