### PR TITLE
Add MetaAdsAgent for Advantage+ campaigns

### DIFF
--- a/o3research/agents/agent_registry.py
+++ b/o3research/agents/agent_registry.py
@@ -1,6 +1,7 @@
 from typing import Type, Dict
 
 from ..marketing.google_ads_agent import GoogleAdsCampaignAgent
+from ..marketing.meta_ads_agent import MetaAdsAgent
 
 # simple registry mapping names to agent classes
 _AGENT_REGISTRY: Dict[str, Type] = {}
@@ -26,7 +27,9 @@ def clear_registry() -> None:
     _AGENT_REGISTRY.clear()
     # re-register built-in agents
     register_agent("google_ads", GoogleAdsCampaignAgent)
+    register_agent("meta_ads", MetaAdsAgent)
 
 
 # register default agents
 register_agent("google_ads", GoogleAdsCampaignAgent)
+register_agent("meta_ads", MetaAdsAgent)

--- a/o3research/marketing/__init__.py
+++ b/o3research/marketing/__init__.py
@@ -1,5 +1,6 @@
 """Marketing agents package."""
 
 from .google_ads_agent import GoogleAdsCampaignAgent
+from .meta_ads_agent import MetaAdsAgent
 
-__all__ = ["GoogleAdsCampaignAgent"]
+__all__ = ["GoogleAdsCampaignAgent", "MetaAdsAgent"]

--- a/o3research/marketing/meta_ads_agent.py
+++ b/o3research/marketing/meta_ads_agent.py
@@ -1,0 +1,24 @@
+from ..core.base_agent import BaseAgent
+
+
+class MetaAdsAgent(BaseAgent):
+    """Generate a Meta Advantage+ style campaign plan."""
+
+    def __init__(self) -> None:
+        super().__init__(name="MetaAdsAgent")
+
+    def run(self, offer: str) -> str:
+        """Return a simplified Advantage+ ad strategy."""
+        summary_ref = "docs/performance_marketing/meta_ai_strategy.md lines 8-11"
+        plan = (
+            f"Advantage+ campaign for {offer}:\n"
+            "- Leverage dynamic creative optimization to mix ad assets\n"
+            "- Enable audience expansion to find high-value buyers\n"
+            f"(See {summary_ref})"
+        )
+        return plan
+
+
+if __name__ == "__main__":  # pragma: no cover
+    agent = MetaAdsAgent()
+    print(agent.run("new product"))

--- a/tests/golden_prompts/test_meta_ads_campaign.md
+++ b/tests/golden_prompts/test_meta_ads_campaign.md
@@ -1,0 +1,15 @@
+# Meta Ads Advantage+ Campaign
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
+Outline an Advantage+ campaign for a new product using Meta Ads.
+
+### EXPECTED
+- Mentions dynamic creative optimization
+- Includes audience expansion features
+- References Advantage+ automation benefits
+
+### NOTES
+Prompt Kernel: v3.5.7
+**Tags:** meta ads, advantage+
+

--- a/tests/test_meta_ads_agent.py
+++ b/tests/test_meta_ads_agent.py
@@ -1,0 +1,22 @@
+import unittest
+
+from o3research.marketing import MetaAdsAgent
+from o3research.agents.agent_registry import get_agent
+
+
+class TestMetaAdsAgent(unittest.TestCase):
+    def test_plan_generation(self) -> None:
+        agent = MetaAdsAgent()
+        plan = agent.run("mobile app")
+        self.assertIn("Advantage+", plan)
+        self.assertIn("dynamic creative", plan.lower())
+        self.assertIn("audience expansion", plan.lower())
+        self.assertIn("docs/performance_marketing/meta_ai_strategy.md", plan)
+
+    def test_registry_lookup(self) -> None:
+        cls = get_agent("meta_ads")
+        self.assertIs(cls, MetaAdsAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MetaAdsAgent` to generate Advantage+ style campaign plans
- export via marketing package and register in agent registry
- validate behaviour with unit tests and new golden prompt

## Testing
- `black o3research tests/test_meta_ads_agent.py`
- `flake8`
- `mypy o3research`
- `pytest`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `jq . docs/source_index.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/validate_versions.sh`
- `bash scripts/offline_link_check.sh --warn-only`


------
https://chatgpt.com/codex/tasks/task_b_6847b4925080833394748e82557fefdf