### PR TITLE
feat: add budget allocator agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 - Added `refresh_link_cache.py` script for external link validation
 - Clarified prompt genome status and cleaned documentation
 - Added `MetricsCollector` with KPI calculations and docs
+- Added `BudgetAllocatorAgent` and ROAS planning guide
 
 ## [v3.5.6] — 2025-05-31
 

--- a/docs/performance_marketing/README.md
+++ b/docs/performance_marketing/README.md
@@ -12,6 +12,7 @@ This directory compiles research notes and strategies for data-driven advertisin
 - `reforge_growth_loops.md`
 - `skai_roi_optimization.md`
 - `smartly_creative_ai.md`
+- `budget_allocation.md`
 
 ## Usage
 

--- a/docs/performance_marketing/budget_allocation.md
+++ b/docs/performance_marketing/budget_allocation.md
@@ -1,0 +1,13 @@
+# ROAS-Driven Budget Allocation
+
+**Source**: Internal methodology
+**Focus**: Allocate spend using return on ad spend goals
+
+## Key Steps
+
+1. Gather historical metrics per channel using `MetricsCollector`.
+2. Calculate recommended spend based on target ROAS or CPA.
+3. Distribute budget toward channels exceeding goal performance.
+4. Divide total allocation by 30 to set a daily budget benchmark.
+
+This approach keeps spend aligned with profitability while reacting to channel-level results.

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -349,6 +349,17 @@
       "version": "1.0.0"
     },
     {
+      "name": "ROAS-Driven Budget Allocation",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/budget_allocation.md",
+      "tags": [
+        "budget",
+        "allocation",
+        "roas",
+        "planning"
+      ],
+      "version": "1.0.0"
+    },
+    {
       "name": "Performance Marketing Resource Index",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/README.md",
       "tags": [

--- a/o3research/agents/agent_registry.py
+++ b/o3research/agents/agent_registry.py
@@ -2,6 +2,7 @@ from typing import Type, Dict
 
 from ..marketing.google_ads_agent import GoogleAdsCampaignAgent
 from ..marketing.meta_ads_agent import MetaAdsAgent
+from ..marketing.budget_allocator import BudgetAllocatorAgent
 
 # simple registry mapping names to agent classes
 _AGENT_REGISTRY: Dict[str, Type] = {}
@@ -28,8 +29,10 @@ def clear_registry() -> None:
     # re-register built-in agents
     register_agent("google_ads", GoogleAdsCampaignAgent)
     register_agent("meta_ads", MetaAdsAgent)
+    register_agent("budget_allocator", BudgetAllocatorAgent)
 
 
 # register default agents
 register_agent("google_ads", GoogleAdsCampaignAgent)
 register_agent("meta_ads", MetaAdsAgent)
+register_agent("budget_allocator", BudgetAllocatorAgent)

--- a/o3research/marketing/__init__.py
+++ b/o3research/marketing/__init__.py
@@ -2,5 +2,6 @@
 
 from .google_ads_agent import GoogleAdsCampaignAgent
 from .meta_ads_agent import MetaAdsAgent
+from .budget_allocator import BudgetAllocatorAgent
 
-__all__ = ["GoogleAdsCampaignAgent", "MetaAdsAgent"]
+__all__ = ["GoogleAdsCampaignAgent", "MetaAdsAgent", "BudgetAllocatorAgent"]

--- a/o3research/marketing/budget_allocator.py
+++ b/o3research/marketing/budget_allocator.py
@@ -1,0 +1,61 @@
+from typing import Dict, Union
+
+from ..core.base_agent import BaseAgent
+
+
+class BudgetAllocatorAgent(BaseAgent):
+    """Allocate budget across channels based on performance goals."""
+
+    def __init__(self) -> None:
+        super().__init__(name="BudgetAllocatorAgent")
+
+    def run(  # type: ignore[override]
+        self,
+        channel_metrics: Dict[str, Dict[str, Union[int, float]]],
+        target: float,
+        goal: str = "CPA",
+    ) -> str:
+        """Return recommended spend per channel and daily budget.
+
+        Parameters
+        ----------
+        channel_metrics:
+            Mapping of channel names to metric dicts with
+            ``conversions`` and ``revenue``.
+        target:
+            Desired CPA or ROAS value.
+        goal:
+            Either ``"CPA"`` or ``"ROAS"`` determining how allocations are computed.
+        """
+        allocation: Dict[str, float] = {}
+        total_spend = 0.0
+
+        goal_upper = goal.upper()
+        for channel, metrics in channel_metrics.items():
+            conversions = float(metrics.get("conversions", 0))
+            revenue = float(metrics.get("revenue", 0))
+
+            if goal_upper == "ROAS":
+                spend = revenue / target if target else 0.0
+            else:  # default CPA
+                spend = target * conversions
+
+            allocation[channel] = round(spend, 2)
+            total_spend += spend
+
+        daily_budget = round(total_spend / 30.0, 2)
+
+        lines = [f"Recommended spend per channel ({goal_upper} target {target}):"]
+        for ch, spend in allocation.items():
+            lines.append(f"- {ch}: ${spend}")
+        lines.append(f"Daily budget: ${daily_budget}")
+        return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    example_metrics = {
+        "search": {"conversions": 30.0, "revenue": 1200.0},
+        "social": {"conversions": 20.0, "revenue": 800.0},
+    }
+    agent = BudgetAllocatorAgent()
+    print(agent.run(example_metrics, target=10, goal="CPA"))

--- a/tests/test_budget_allocator.py
+++ b/tests/test_budget_allocator.py
@@ -1,0 +1,36 @@
+import unittest
+
+from o3research.marketing import BudgetAllocatorAgent
+from o3research.agents.agent_registry import get_agent
+
+
+class TestBudgetAllocatorAgent(unittest.TestCase):
+    def test_allocation_cpa(self) -> None:
+        metrics = {
+            "search": {"conversions": 30, "revenue": 1200},
+            "social": {"conversions": 20, "revenue": 800},
+        }
+        agent = BudgetAllocatorAgent()
+        result = agent.run(metrics, target=10, goal="CPA")
+        self.assertIn("search: $300", result)
+        self.assertIn("social: $200", result)
+        self.assertIn("Daily budget: $16.67", result)
+
+    def test_allocation_roas(self) -> None:
+        metrics = {
+            "search": {"conversions": 30, "revenue": 1200},
+            "social": {"conversions": 20, "revenue": 800},
+        }
+        agent = BudgetAllocatorAgent()
+        result = agent.run(metrics, target=2, goal="ROAS")
+        self.assertIn("search: $600", result)
+        self.assertIn("social: $400", result)
+        self.assertIn("Daily budget: $33.33", result)
+
+    def test_registry_lookup(self) -> None:
+        cls = get_agent("budget_allocator")
+        self.assertIs(cls, BudgetAllocatorAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `BudgetAllocatorAgent` for channel spend planning
- document ROAS-driven budget allocation
- register and expose the new agent
- test spend allocation logic

## Testing
- `bash scripts/setup_env.sh`
- `npm ci --omit=optional`
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json >/dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `mypy o3research`
- `flake8`
- `black --check .`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_6847b5c1bc0083339d0e3f4b13a6a2b3