### PR TITLE
feat: add funnel planner agent

### DIFF
--- a/o3research/agents/agent_registry.py
+++ b/o3research/agents/agent_registry.py
@@ -3,6 +3,7 @@ from typing import Type, Dict
 from ..marketing.google_ads_agent import GoogleAdsCampaignAgent
 from ..marketing.meta_ads_agent import MetaAdsAgent
 from ..marketing.budget_allocator import BudgetAllocatorAgent
+from ..marketing.funnel_planner import FunnelPlannerAgent
 
 # simple registry mapping names to agent classes
 _AGENT_REGISTRY: Dict[str, Type] = {}
@@ -30,9 +31,11 @@ def clear_registry() -> None:
     register_agent("google_ads", GoogleAdsCampaignAgent)
     register_agent("meta_ads", MetaAdsAgent)
     register_agent("budget_allocator", BudgetAllocatorAgent)
+    register_agent("funnel_planner", FunnelPlannerAgent)
 
 
 # register default agents
 register_agent("google_ads", GoogleAdsCampaignAgent)
 register_agent("meta_ads", MetaAdsAgent)
 register_agent("budget_allocator", BudgetAllocatorAgent)
+register_agent("funnel_planner", FunnelPlannerAgent)

--- a/o3research/marketing/__init__.py
+++ b/o3research/marketing/__init__.py
@@ -3,5 +3,11 @@
 from .google_ads_agent import GoogleAdsCampaignAgent
 from .meta_ads_agent import MetaAdsAgent
 from .budget_allocator import BudgetAllocatorAgent
+from .funnel_planner import FunnelPlannerAgent
 
-__all__ = ["GoogleAdsCampaignAgent", "MetaAdsAgent", "BudgetAllocatorAgent"]
+__all__ = [
+    "GoogleAdsCampaignAgent",
+    "MetaAdsAgent",
+    "BudgetAllocatorAgent",
+    "FunnelPlannerAgent",
+]

--- a/o3research/marketing/funnel_planner.py
+++ b/o3research/marketing/funnel_planner.py
@@ -1,0 +1,32 @@
+from ..core.base_agent import BaseAgent
+
+
+class FunnelPlannerAgent(BaseAgent):
+    """Create a simple marketing funnel with actions for each stage."""
+
+    def __init__(self) -> None:
+        super().__init__(name="FunnelPlannerAgent")
+
+    def run(self, product_type: str, goal: str) -> str:  # type: ignore[override]
+        """Return funnel stages for the given product and goal."""
+        ref = "docs/performance_marketing/reforge_growth_loops.md lines 9-25"
+        goal_lower = goal.lower()
+        tofu_action = "subscribe" if goal_lower == "lead" else "learn more"
+        mofu_action = "request demo" if goal_lower == "sale" else "download guide"
+        bofu_action = "purchase" if goal_lower == "sale" else "contact sales"
+        lines = [
+            f"Funnel plan for {product_type} ({goal_lower} goal):",
+            "TOFU: awareness content -> blogs, social videos",
+            f"  - Primary CTA: {tofu_action}",
+            "MOFU: education -> webinars, case studies",
+            f"  - Primary CTA: {mofu_action}",
+            "BOFU: conversion -> pricing page, retargeting ads",
+            f"  - Primary CTA: {bofu_action}",
+            f"(See {ref})",
+        ]
+        return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    agent = FunnelPlannerAgent()
+    print(agent.run("software", "lead"))

--- a/tests/golden_prompts/test_funnel_planner.md
+++ b/tests/golden_prompts/test_funnel_planner.md
@@ -1,0 +1,14 @@
+# Funnel Planner
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
+Design a simple marketing funnel for a SaaS offering focused on lead generation.
+
+### EXPECTED
+- Lists TOFU, MOFU, and BOFU stages
+- Shows branching actions for lead or sale goals
+- References growth loops research
+
+### NOTES
+Prompt Kernel: v3.5.7
+**Tags:** funnel planning, growth loops

--- a/tests/test_funnel_planner.py
+++ b/tests/test_funnel_planner.py
@@ -1,0 +1,22 @@
+import unittest
+
+from o3research.marketing import FunnelPlannerAgent
+from o3research.agents.agent_registry import get_agent
+
+
+class TestFunnelPlannerAgent(unittest.TestCase):
+    def test_plan_generation(self) -> None:
+        agent = FunnelPlannerAgent()
+        plan = agent.run("SaaS", "lead")
+        self.assertIn("TOFU", plan)
+        self.assertIn("MOFU", plan)
+        self.assertIn("BOFU", plan)
+        self.assertIn("docs/performance_marketing/reforge_growth_loops.md", plan)
+
+    def test_registry_lookup(self) -> None:
+        cls = get_agent("funnel_planner")
+        self.assertIs(cls, FunnelPlannerAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add FunnelPlannerAgent to design marketing funnels
- register funnel_planner in agent registry
- expose new agent in marketing package
- test FunnelPlannerAgent functionality and registry
- add golden prompt for funnel planning

## Testing
- `black --check .`
- `flake8`
- `mypy o3research`
- `npx markdownlint-cli2 "docs/**/*.md" "\!docs/legacy/**"`
- `bash scripts/validate_yaml.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847b83b1e1483339849ae7cea9992a5