### PR TITLE
feat: add creative prompt agent

### DIFF
--- a/o3research/agents/agent_registry.py
+++ b/o3research/agents/agent_registry.py
@@ -4,6 +4,7 @@ from ..marketing.google_ads_agent import GoogleAdsCampaignAgent
 from ..marketing.meta_ads_agent import MetaAdsAgent
 from ..marketing.budget_allocator import BudgetAllocatorAgent
 from ..marketing.funnel_planner import FunnelPlannerAgent
+from ..marketing.creative_prompt_agent import CreativePromptAgent
 
 # simple registry mapping names to agent classes
 _AGENT_REGISTRY: Dict[str, Type] = {}
@@ -32,6 +33,7 @@ def clear_registry() -> None:
     register_agent("meta_ads", MetaAdsAgent)
     register_agent("budget_allocator", BudgetAllocatorAgent)
     register_agent("funnel_planner", FunnelPlannerAgent)
+    register_agent("creative_prompt", CreativePromptAgent)
 
 
 # register default agents
@@ -39,3 +41,4 @@ register_agent("google_ads", GoogleAdsCampaignAgent)
 register_agent("meta_ads", MetaAdsAgent)
 register_agent("budget_allocator", BudgetAllocatorAgent)
 register_agent("funnel_planner", FunnelPlannerAgent)
+register_agent("creative_prompt", CreativePromptAgent)

--- a/o3research/marketing/__init__.py
+++ b/o3research/marketing/__init__.py
@@ -4,10 +4,12 @@ from .google_ads_agent import GoogleAdsCampaignAgent
 from .meta_ads_agent import MetaAdsAgent
 from .budget_allocator import BudgetAllocatorAgent
 from .funnel_planner import FunnelPlannerAgent
+from .creative_prompt_agent import CreativePromptAgent
 
 __all__ = [
     "GoogleAdsCampaignAgent",
     "MetaAdsAgent",
     "BudgetAllocatorAgent",
     "FunnelPlannerAgent",
+    "CreativePromptAgent",
 ]

--- a/o3research/marketing/creative_prompt_agent.py
+++ b/o3research/marketing/creative_prompt_agent.py
@@ -1,0 +1,22 @@
+from ..core.base_agent import BaseAgent
+
+
+class CreativePromptAgent(BaseAgent):
+    """Generate short ad copy variants for a target persona."""
+
+    def __init__(self) -> None:
+        super().__init__(name="CreativePromptAgent")
+
+    def run(self, product: str, persona: str) -> str:  # type: ignore[override]
+        """Return multiple ad copy lines referencing neuromarketing tactics."""
+        ref = "docs/performance_marketing/neurogym_neuromarketing.md lines 14-23"
+        variants = [
+            f"Imagine if {persona} used {product} and felt unstoppable. Act now!",
+            (
+                f"{persona.capitalize()}, avoid the pain of slow results. "
+                f"{product} unlocks new gains."
+            ),
+            f"See your vision come alive with {product}, {persona}!",
+        ]
+        lines = ["Ad copy variants:"] + [f"- {v}" for v in variants] + [f"(See {ref})"]
+        return "\n".join(lines)

--- a/tests/golden_prompts/test_creative_prompts.md
+++ b/tests/golden_prompts/test_creative_prompts.md
@@ -1,0 +1,14 @@
+# Creative Prompt Variants
+<!-- markdownlint-disable MD001 -->
+
+### INPUT
+Generate three ad copy lines for a productivity app targeting busy professionals.
+
+### EXPECTED
+- Uses emotional hooks from neuromarketing guidance
+- Balances pain-avoidance and aspirational framing
+- Provides multiple short variants
+
+### NOTES
+Prompt Kernel: v3.5.7
+**Tags:** creative, copywriting

--- a/tests/test_creative_prompt_agent.py
+++ b/tests/test_creative_prompt_agent.py
@@ -1,0 +1,22 @@
+import unittest
+
+from o3research.marketing import CreativePromptAgent
+from o3research.agents.agent_registry import get_agent
+
+
+class TestCreativePromptAgent(unittest.TestCase):
+    def test_copy_generation(self) -> None:
+        agent = CreativePromptAgent()
+        result = agent.run("AI tool", "busy marketer")
+        self.assertIn("Ad copy variants", result)
+        self.assertIn("AI tool", result)
+        self.assertIn("busy marketer", result)
+        self.assertIn("docs/performance_marketing/neurogym_neuromarketing.md", result)
+
+    def test_registry_lookup(self) -> None:
+        cls = get_agent("creative_prompt")
+        self.assertIs(cls, CreativePromptAgent)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 📋 Description of Changes
- Added `CreativePromptAgent` module for generating persona-based ad copy variants
- Registered agent in `agent_registry`
- Exported in `marketing` package
- Added unit tests and golden prompt reference

## 🗂 Affected Files (v3.5.7)
- `o3research/marketing/creative_prompt_agent.py`
- `o3research/agents/agent_registry.py`
- `o3research/marketing/__init__.py`
- `tests/test_creative_prompt_agent.py`
- `tests/golden_prompts/test_creative_prompts.md`

## ✅ Validation Checklist
- [x] Golden prompts pass validation checks
- [x] All tests are passing
- [x] No incomplete work remains


------
https://chatgpt.com/codex/tasks/task_b_6847b9d0182c8333b361332e317bf468