### PR TITLE
docs: add PPC loops and LTV models

### DIFF
--- a/docs/performance_marketing/README.md
+++ b/docs/performance_marketing/README.md
@@ -13,6 +13,8 @@ This directory compiles research notes and strategies for data-driven advertisin
 - `skai_roi_optimization.md`
 - `smartly_creative_ai.md`
 - `budget_allocation.md`
+- `ppc_growth_loops.md`
+- `ltv_models.md`
 
 ## Usage
 

--- a/docs/performance_marketing/ltv_models.md
+++ b/docs/performance_marketing/ltv_models.md
@@ -1,0 +1,41 @@
+# Customer Lifetime Value Models
+
+**Focus**: Estimating long‑term value to inform budget decisions
+
+## Basic Calculation
+
+```
+LTV = Average Revenue per User * Gross Margin % * Retention Period
+```
+
+Where *Retention Period* measures how long users remain active.
+
+## Cohort Approach
+
+Segment users by acquisition channel and estimate LTV for each cohort.
+
+```python
+def calculate_ltv(revenue: float, conversions: int, months: int) -> float:
+    arpu = revenue / conversions if conversions else 0
+    return arpu * months
+```
+
+## Using LTV with BudgetAllocatorAgent
+
+```
+metrics = {
+    "search": {"conversions": 50, "revenue": 2000, "ltv": 60},
+    "social": {"conversions": 30, "revenue": 900, "ltv": 45},
+}
+```
+
+Call `BudgetAllocatorAgent.run(metrics, target=3, goal="ROAS")` to weigh spend by expected lifetime value.
+
+```mermaid
+flowchart LR
+    M[Metrics Collector] --> L[Calculate LTV]
+    L --> A[BudgetAllocatorAgent]
+    A --> S[Spend Recommendations]
+```
+
+The agent logs prompts when `PROMPT_OBSERVABILITY=1` via `record_prompt`.

--- a/docs/performance_marketing/ppc_growth_loops.md
+++ b/docs/performance_marketing/ppc_growth_loops.md
@@ -1,0 +1,41 @@
+# PPC Growth Loops
+
+**Source**: Reforge methodology adapted for paid advertising
+**Focus**: Connecting campaign automation to iterative growth loops
+
+## Loop Stages
+
+1. **Traffic Generation** – Acquire clicks from search or social platforms.
+2. **Conversion Feedback** – Collect conversions and revenue in near real time.
+3. **Budget Reallocation** – Shift spend toward high‑return channels.
+4. **Creative Refresh** – Generate new ad copy or assets based on results.
+
+Each stage feeds the next, creating a reinforcing cycle when metrics improve.
+
+## Agent Mapping
+
+| Loop Stage | Responsible Agent | Prompt Example |
+|------------|------------------|----------------|
+| Traffic Generation | `GoogleAdsCampaignAgent`, `MetaAdsAgent` | "Launch promo with focus keywords X" |
+| Conversion Feedback | `MetricsCollector` via `AsyncEventBus` | n/a |
+| Budget Reallocation | `BudgetAllocatorAgent` | "Allocate $X with ROAS goal" |
+| Creative Refresh | `CreativePromptAgent` | "Rewrite top ad using pain‑point Y" |
+
+## Event‑Driven Automation
+
+```mermaid
+flowchart TD
+    A[Campaign Launch] --> B{Metrics Observability}
+    B -->|Conversions| C[BudgetAllocatorAgent]
+    C --> D[Spend Update]
+    D --> E[CreativePromptAgent]
+    E --> A
+```
+
+### Observability Example
+
+```python
+from o3research.marketing.prompt_observability import record_prompt
+
+record_prompt("budget_cycle", "BudgetAllocatorAgent", "allocated spend")
+```

--- a/docs/source_index.json
+++ b/docs/source_index.json
@@ -360,6 +360,28 @@
       "version": "1.0.0"
     },
     {
+      "name": "PPC Growth Loops",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/ppc_growth_loops.md",
+      "tags": [
+        "ppc",
+        "growth",
+        "loops",
+        "automation"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "name": "Customer Lifetime Value Models",
+      "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/ltv_models.md",
+      "tags": [
+        "ltv",
+        "customer-value",
+        "budget",
+        "allocation"
+      ],
+      "version": "1.0.0"
+    },
+    {
       "name": "Performance Marketing Resource Index",
       "link": "https://github.com/DanCanadian/ADK/blob/main/docs/performance_marketing/README.md",
       "tags": [


### PR DESCRIPTION
## Summary
- document PPC growth loops mapped to agents
- explain lifetime value models for BudgetAllocatorAgent
- link new docs from the performance marketing index
- register new docs in source_index.json

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_versions.sh`
- `bash scripts/validate_golden_prompts.sh`
- `python3 scripts/refresh_link_cache.py`
- `bash scripts/offline_link_check.sh --warn-only`


------
https://chatgpt.com/codex/tasks/task_b_6847be170bc08333846193c0e6d8a4c2