### PR TITLE
feat: extend marketing workflow

### DIFF
--- a/docs/integration_guide_o3.md
+++ b/docs/integration_guide_o3.md
@@ -87,3 +87,15 @@ This repository serves as the knowledge foundation for the O3 Deep Research syst
 - **Current Version:** 3.5.7
 - **Last Updated:** 2025-06-01
 - **Compatibility:** Designed for use with O3 Deep Research V3.0 and above
+
+## Running Example Workflows
+
+Execute the reference scripts to see the agents in action:
+
+```bash
+python examples/simple_workflow.py
+python examples/marketing_workflow.py
+```
+
+The marketing workflow showcases `GoogleAdsCampaignAgent` and
+`BudgetAllocatorAgent` coordinating via the async event bus.

--- a/examples/marketing_workflow.py
+++ b/examples/marketing_workflow.py
@@ -6,6 +6,11 @@ from o3research.core import AsyncEventBus, get_logger
 from o3research.agents.campaign_agent import CampaignAgent
 from o3research.agents.engagement_agent import EngagementAgent
 from o3research.agents.analytics_agent import AnalyticsAgent
+from o3research.marketing import (
+    GoogleAdsCampaignAgent,
+    BudgetAllocatorAgent,
+    CreativePromptAgent,
+)
 
 
 event_bus = AsyncEventBus()
@@ -14,6 +19,9 @@ logger = get_logger("MarketingWorkflow")
 campaign_agent = CampaignAgent()
 engagement_agent = EngagementAgent()
 analytics_agent = AnalyticsAgent()
+google_ads_agent = GoogleAdsCampaignAgent()
+budget_agent = BudgetAllocatorAgent()
+creative_agent = CreativePromptAgent()
 
 
 async def handle_campaign(product: str) -> None:
@@ -21,6 +29,17 @@ async def handle_campaign(product: str) -> None:
     # Advantage+ approach for dynamic creative optimization
     # docs/performance_marketing/meta_ai_strategy.md lines 8-11
     logger.info(campaign_agent.run(product))
+    logger.info(google_ads_agent.run(product))
+    await event_bus.publish("allocate", product)
+
+
+async def handle_allocate(product: str) -> None:
+    """Allocate budget then trigger engagement."""
+    metrics = {
+        "search": {"conversions": 30, "revenue": 1200},
+        "social": {"conversions": 20, "revenue": 800},
+    }
+    logger.info(budget_agent.run(metrics, target=2, goal="ROAS"))
     await event_bus.publish("engage", f"prospect interested in {product}")
 
 
@@ -29,6 +48,7 @@ async def handle_engage(prospect: str) -> None:
     # Smart Bidding concepts apply to lead targeting
     # docs/performance_marketing/google_insights_summary.md lines 8-11
     logger.info(engagement_agent.run(prospect))
+    logger.info(creative_agent.run(prospect, "busy marketer"))
     await event_bus.publish("report", f"conversion data for {prospect}")
 
 
@@ -40,6 +60,7 @@ async def handle_report(data: str) -> None:
 
 
 event_bus.subscribe("launch", handle_campaign)
+event_bus.subscribe("allocate", handle_allocate)
 event_bus.subscribe("engage", handle_engage)
 event_bus.subscribe("report", handle_report)
 

--- a/tests/test_marketing_workflow.py
+++ b/tests/test_marketing_workflow.py
@@ -1,0 +1,19 @@
+import io
+import runpy
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+
+
+class TestMarketingWorkflowExample(unittest.TestCase):
+    def test_example_runs(self) -> None:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer), redirect_stderr(buffer):
+            runpy.run_module("examples.marketing_workflow", run_name="__main__")
+        output = buffer.getvalue()
+        self.assertIn("Plan for new SaaS product", output)
+        self.assertIn("Recommended spend per channel", output)
+        self.assertIn("AnalyticsAgent analyzed data", output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend example marketing workflow to use latest agents
- document running demo workflows
- test marketing workflow example

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_versions.sh`
- `flake8`
- `black --check .`
- `mypy o3research`
- `pytest -q`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `bash scripts/offline_link_check.sh --warn-only`


------
https://chatgpt.com/codex/tasks/task_b_6847bf824504833387ad2e47f1906446