### PR TITLE
docs: add quick-start snippets for marketing agents

### DIFF
--- a/docs/performance_marketing/README.md
+++ b/docs/performance_marketing/README.md
@@ -26,3 +26,46 @@ from o3research.marketing import GoogleAdsCampaignAgent
 agent = GoogleAdsCampaignAgent()
 print(agent.run("example offer"))
 ```
+
+Use `MetaAdsAgent` to generate a Meta Advantage+ plan:
+
+```python
+from o3research.marketing import MetaAdsAgent
+
+agent = MetaAdsAgent()
+print(agent.run("new product"))
+```
+
+Allocate spend across channels with `BudgetAllocatorAgent`:
+
+```python
+from o3research.marketing import BudgetAllocatorAgent
+
+metrics = {
+    "search": {"conversions": 50, "revenue": 2000},
+    "social": {"conversions": 20, "revenue": 900},
+}
+
+agent = BudgetAllocatorAgent()
+print(agent.run(metrics, target=3, goal="ROAS"))
+```
+
+Plan a marketing funnel with `FunnelPlannerAgent`:
+
+```python
+from o3research.marketing import FunnelPlannerAgent
+
+agent = FunnelPlannerAgent()
+print(agent.run("software", "lead"))
+```
+
+Create short ad copy using `CreativePromptAgent`:
+
+```python
+from o3research.marketing import CreativePromptAgent
+
+agent = CreativePromptAgent()
+print(agent.run("smartwatch", "athlete"))
+```
+
+To log prompts for debugging, set the environment variable `PROMPT_OBSERVABILITY=1` before running any agent.


### PR DESCRIPTION
## Summary
- expand performance marketing README usage section
- show how to instantiate MetaAdsAgent, BudgetAllocatorAgent, FunnelPlannerAgent and CreativePromptAgent
- document `PROMPT_OBSERVABILITY=1` environment variable

## Testing
- `npx markdownlint-cli2 'docs/**/*.md' '!docs/legacy/**'`
- `jq . docs/source_index.json >/dev/null && jq . docs/meta/prompt_genome.json >/dev/null && jq . docs/meta/meta_evaluation.json >/dev/null`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash -c 'REQUIRED=("docs/prompt/prompt_kernel_v3.5.md" "docs/meta/prompt_evolution_log/v3.5.yaml" "docs/meta/meta_evaluation.json" "docs/meta/prompt_genome.json" "docs/source_index.json" "README.md" "CHANGELOG.md"); for f in "${REQUIRED[@]}"; do echo Checking $f; test -f "$f" && echo Found || (echo Missing && exit 1); done'`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `bash scripts/validate_versions.sh`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml && coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_6847c4d029308333995a7a1def7d8780