### PR TITLE
docs: reference prompt observability

### DIFF
--- a/docs/integration_guide_o3.md
+++ b/docs/integration_guide_o3.md
@@ -99,3 +99,5 @@ python examples/marketing_workflow.py
 
 The marketing workflow showcases `GoogleAdsCampaignAgent` and
 `BudgetAllocatorAgent` coordinating via the async event bus.
+For insight into how prompts are logged during execution, see
+[analytics/prompt_observability.md](analytics/prompt_observability.md).

--- a/docs/performance_marketing/README.md
+++ b/docs/performance_marketing/README.md
@@ -69,3 +69,4 @@ print(agent.run("smartwatch", "athlete"))
 ```
 
 To log prompts for debugging, set the environment variable `PROMPT_OBSERVABILITY=1` before running any agent.
+See the [Prompt Observability guide](../analytics/prompt_observability.md) for details on how the logging pipeline works.


### PR DESCRIPTION
## Summary
- insert link to the prompt observability guide in performance marketing README
- mention the prompt observability docs in the integration guide near the marketing workflow section

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `jq . docs/meta/prompt_genome.json`
- `jq . docs/meta/meta_evaluation.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_versions.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/offline_link_check.sh --warn-only`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_6847c73f46e48333bac41975111385fb