### PR TITLE
Fix README link check comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Hosted online at [https://dancanadian.github.io/ADK/](https://dancanadian.github
 
 ### Project Management
 - [Contribution Guide](docs/contribution_guide.md) - How to contribute to the project
-  (see checklist; link cache warnings are logged but do not fail the build unless `STRICT_LINKS=1`)
+  (see checklist; link checker warnings are logged but do not fail the build unless `STRICT_LINKS=1`)
 - [Release Checklist](docs/meta/release_checklist_v3.5.md) - Process for new releases
 - [Changelog](CHANGELOG.md) - Version history and changes
 
@@ -121,7 +121,7 @@ markdownlint-cli2 "**/*.md" "#node_modules"
 bash scripts/check_incomplete_work.sh
 # Rebuild source index and run online link check
 python3 scripts/update_source_index.py
-# offline check defaults to warn-only mode
+# link check defaults to warn-only mode
 bash scripts/online_link_check.sh
 # enforce strict behavior with environment variable or flag
 STRICT_LINKS=1 bash scripts/online_link_check.sh


### PR DESCRIPTION
## Summary
- tweak README wording around link checker warnings
- clarify link check defaults

## Testing
- `npx markdownlint-cli2 "docs/**/*.md" '!docs/legacy/**'`
- `jq . docs/source_index.json`
- `bash scripts/validate_yaml.sh`
- `bash scripts/check_incomplete_work.sh`
- `bash scripts/validate_golden_prompts.sh`
- `bash scripts/validate_versions.sh`
- `flake8`
- `black --check .`
- `mypy o3research`
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=80`
- `python scripts/generate_evaluation.py tests/sample_metrics.json`
- `bash scripts/online_link_check.sh --warn-only` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_6847cf4e6840833393c9497c9ab3e1bc